### PR TITLE
Markdown formatting improvements

### DIFF
--- a/BasicCABI.md
+++ b/BasicCABI.md
@@ -1,14 +1,16 @@
-This document describes the "Basic” C ABI for WebAssembly. As mentioned in
-README.md, it's not the only possible C ABI. It is the ABI that the clang/LLVM
-WebAssembly backend is currently using, and any other C or C++ compiler wishing
-to be ABI-compatible with it.
+This document describes the "Basic" C ABI for WebAssembly. As mentioned in
+[README](README.md), it's not the only possible C ABI. It is the ABI that the
+clang/LLVM WebAssembly backend is currently using, and any other C or C++
+compiler wishing to be ABI-compatible with it.
 
 wasm32 is ILP32 and wasm64 is LP64. `float` and `double` map to wasm’s `f32` and
-`f64` respectively. Varargs is lowered to passing a pointer to an
-explicitly-allocated buffer. Single-element struct return values are returned by
-a normal wasm return value. TODO: Spell this all out in much more detail.
+`f64` respectively.  Varargs is lowered to passing a pointer to an
+explicitly-allocated buffer.  Single-element struct return values are returned
+by a normal wasm return value. TODO: Spell this all out in much more detail.
 
-This is just an initial sketch of some content. Obviously, it would
-be desirable to go into a lot more detail.
+This is just an initial sketch of some content. Obviously, it would be desirable
+to go into a lot more detail.
 
-Eventually, some content from the design repo’s CAndC++.md should also be moved here.
+Eventually, some content from the design repo's
+[CAndC++](https://github.com/WebAssembly/design/blob/master/CAndC++) should also
+be moved here.

--- a/ItaniumLikeC++ABI.md
+++ b/ItaniumLikeC++ABI.md
@@ -1,11 +1,16 @@
-This document describes the "Itanium-like” C++ ABI for WebAssembly. As mentioned in README.md, it's not the only possible C++ ABI or even the only possible Itanium-derived C++ ABI for WebAssembly. It is the ABI that the clang/LLVM WebAssembly backend is currently using, and any other C++ compiler wishing to be ABI-compatible with it.
+This document describes the "Itanium-like" C++ ABI for WebAssembly. As mentioned
+in [README](README.md), it's not the only possible C++ ABI or even the only
+possible Itanium-derived C++ ABI for WebAssembly. It is the ABI that the
+clang/LLVM WebAssembly backend is currently using, and any other C++ compiler
+wishing to be ABI-compatible with it.
 
 Most details follow
 [the base Itanium C++ ABI](https://mentorembedded.github.io/cxx-abi/abi.html).
 
 The following is a brief summary of deviations from this base:
 
- - The least-significant bit of the `adj` field of a member-function pointer is used to indicate whether the indicated function is virtual.
+ - The least-significant bit of the `adj` field of a member-function pointer is
+   used to indicate whether the indicated function is virtual.
  - Member functions are not specially aligned.
  - Constructors and destructors return `this`.
  - Guard variables are 32-bit on wasm32.
@@ -15,9 +20,18 @@ The following is a brief summary of deviations from this base:
 
 The following are ideas for additional deviations that are being considered:
 
- - The Itanium C++ name mangling rules have special-case abbreviations for std::string, std::allocator, and a few others, however libc++ doesn’t get to take advantage of them because it uses a versioned namespace. It may be useful to add new special-cases to cover libc++’s mangled names for std::string et al.
- - There’s an interesting idea for a vtable optimization described [here](https://llvm.org/bugs/show_bug.cgi?id=26723) that’s worth thinking about.
- - Alternatively, the design of vtables may radically change to take better advantage of WebAssembly’s function table mechanisms.
-  - Trivially copyable classes may be passed by value rather than by pointer. This would cover a lot of common C++ classes such as std::pair.
+ - The Itanium C++ name mangling rules have special-case abbreviations for
+   std::string, std::allocator, and a few others, however libc++ doesn’t get to
+   take advantage of them because it uses a versioned namespace. It may be
+   useful to add new special-cases to cover libc++’s mangled names for
+   std::string et al.
+ - There’s an interesting idea for a vtable optimization described
+   [here](https://llvm.org/bugs/show_bug.cgi?id=26723) that’s worth thinking
+   about.
+ - Alternatively, the design of vtables may radically change to take better
+   advantage of WebAssembly’s function table mechanisms.
+ - Trivially copyable classes may be passed by value rather than by pointer.
+   This would cover a lot of common C++ classes such as std::pair.
 
-This is just an initial sketch of the kind of content we plan to have here. Obviously it would be desirable to go into a lot more detail.
+This is just an initial sketch of the kind of content we plan to have here.
+Obviously it would be desirable to go into a lot more detail.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-This repository holds documents describing *conventions* useful for coordinating interoperability between wasm-related tools. This includes descriptions of intermediate file formats, conventions for mapping high-level language types, names, and abstraction features to WebAssembly types, identifiers, and implementations, and schemes for supporting debuggers or other tools.
+WebAssembly Tool Conventions
+============================
 
-These conventions are not part of the WebAssembly standard, and are not required of WebAssembly-consuming implementations to execute WebAssembly code. Tools producing and working with WebAssembly in other ways also need not follow any of these conventions. They exist only to support tools that wish to interoperate with other tools at a higher abstraction level than just WebAssembly itself.
+This repository holds documents describing *conventions* useful for coordinating
+interoperability between wasm-related tools. This includes descriptions of
+intermediate file formats, conventions for mapping high-level language types,
+names, and abstraction features to WebAssembly types, identifiers, and
+implementations, and schemes for supporting debuggers or other tools.
 
-These conventions are also not exclusive. There could be multiple conventions for a given language for a given purpose. There are natural benefits to interoperability, but there are many reasons where having more than one way to do things can also make sense in m
-any circumstances.
+These conventions are not part of the WebAssembly standard, and are not required
+of WebAssembly-consuming implementations to execute WebAssembly code. Tools
+producing and working with WebAssembly in other ways also need not follow any of
+these conventions. They exist only to support tools that wish to interoperate
+with other tools at a higher abstraction level than just WebAssembly itself.
+
+These conventions are also not exclusive. There could be multiple conventions
+for a given language for a given purpose. There are natural benefits to
+interoperability, but there are many reasons where having more than one way to
+do things can also make sense in m any circumstances.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ with other tools at a higher abstraction level than just WebAssembly itself.
 These conventions are also not exclusive. There could be multiple conventions
 for a given language for a given purpose. There are natural benefits to
 interoperability, but there are many reasons where having more than one way to
-do things can also make sense in m any circumstances.
+do things can also make sense in many circumstances.


### PR DESCRIPTION
- Wrap at 80 cols
- Remove unicode quote chars
- Add title to README.md
- Use links when referencing other .md files