### PR TITLE
Describe the relocations that LLVM is currently using.

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -59,14 +59,15 @@ A relocation type can be one of the following:
   instruction, e.g. taking the address of a function.
 - `2 / R_WEBASSEMBLY_TABLE_INDEX_I32` - a function table index encoded as a
   [uint32], e.g. taking the address of a function in a static data initializer.
-- `3 / R_WEBASSEMBLY_GLOBAL_ADDR_LEB` - a global index encoded as a 5-byte
+- `3 / R_WEBASSEMBLY_MEMORY_ADDR_LEB` - a linear memory index encoded as a 5-byte
   [varuint32]. Used for the immediate argument of a `load` or `store`
   instruction, e.g. directly loading from or storing to a C++ global.
-- `4 / R_WEBASSEMBLY_GLOBAL_ADDR_SLEB` - a global index encoded as a 5-byte
+- `4 / R_WEBASSEMBLY_MEMORY_ADDR_SLEB` - a linear memory index encoded as a 5-byte
   [varint32]. Used for the immediate argument of a `i32.const` instruction,
   e.g. taking the address of a C++ global.
-- `5 / R_WEBASSEMBLY_GLOBAL_ADDR_I32` - a global index encoded as a [uint32],
-  e.g. taking the address of a C++ global in a static data initializer.
+- `5 / R_WEBASSEMBLY_MEMORY_ADDR_I32` - a linear memory index encoded as a
+  [uint32], e.g. taking the address of a C++ global in a static data
+  initializer.
 
 [varuint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varuintn
 [varint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varintn
@@ -81,8 +82,8 @@ present:
 | offset | `varuint32`      | offset of the value to rewrite           |
 | index  | `varuint32`      | the index of the function used           |
 
-For `R_WEBASSEMBLY_GLOBAL_ADDR_LEB`, `R_WEBASSEMBLY_GLOBAL_ADDR_SLEB`,
-and `R_WEBASSEMBLY_GLOBAL_ADDR_I32` relocations the following fields are
+For `R_WEBASSEMBLY_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB`,
+and `R_WEBASSEMBLY_MEMORY_ADDR_I32` relocations the following fields are
 present:
 
 | Field  | Type             | Description                         |

--- a/Linking.md
+++ b/Linking.md
@@ -58,14 +58,15 @@ A relocation type can be one of the following:
   5-byte [varint32]. Used to refer to the immediate argument of a `i32.const`
   instruction, e.g. taking the address of a function.
 - `2 / R_WEBASSEMBLY_TABLE_INDEX_I32` - a function table index encoded as a
-  [uint32].
+  [uint32], e.g. taking the address of a function in a static data initializer.
 - `3 / R_WEBASSEMBLY_GLOBAL_ADDR_LEB` - a global index encoded as a 5-byte
   [varuint32]. Used for the immediate argument of a `load` or `store`
-  instruction.
+  instruction, e.g. directly loading from or storing to a C++ global.
 - `4 / R_WEBASSEMBLY_GLOBAL_ADDR_SLEB` - a global index encoded as a 5-byte
   [varint32]. Used for the immediate argument of a `i32.const` instruction,
-  e.g. taking the address of a function.
-- `5 / R_WEBASSEMBLY_GLOBAL_ADDR_I32` - a global index encoded as a [uint32].
+  e.g. taking the address of a C++ global.
+- `5 / R_WEBASSEMBLY_GLOBAL_ADDR_I32` - a global index encoded as a [uint32],
+  e.g. taking the address of a C++ global in a static data initializer.
 
 [varuint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varuintn
 [varint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varintn

--- a/Linking.md
+++ b/Linking.md
@@ -70,6 +70,8 @@ A relocation type can be one of the following:
   initializer.
 - `6 / R_WEBASSEMBLY_TYPE_INDEX_LEB` - a type table index encoded as a
   5-byte [varuint32], e.g. the type immediate in a `call_indirect`.
+- `7 / R_WEBASSEMBLY_GLOBAL_INDEX_LEB` - a global index encoded as a
+  5-byte [varuint32], e.g. the type immediate in a `get_global`.
 
 [varuint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varuintn
 [varint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varintn
@@ -101,6 +103,14 @@ present:
 | ------ | ---------------- | ----------------------------------- |
 | offset | `varuint32`      | offset of the value to rewrite      |
 | index  | `varuint32`      | the index of the type used          |
+
+For `R_WEBASSEMBLY_GLOBAL_INDEX_LEB` relocations the following fields
+are present:
+
+| Field  | Type             | Description                         |
+| ------ | ---------------- | ----------------------------------- |
+| offset | `varuint32`      | offset of the value to rewrite      |
+| index  | `varuint32`      | the index of the global used        |
 
 Merging Global Section
 ----------------------

--- a/Linking.md
+++ b/Linking.md
@@ -112,16 +112,45 @@ are present:
 | offset | `varuint32`      | offset of the value to rewrite      |
 | index  | `varuint32`      | the index of the global used        |
 
+Linking Metadata Sections
+-------------------------
+
+A linking metadata section is a user-defined section with the name
+"linking".
+
+A linking metadata section contain the following fields:
+
+| Field      | Type                | Description                    |
+| -----------| ------------------- | ------------------------------ |
+| count      | `varuint32`         | count of entries to follow     |
+| entries    | `linking_entry*`    | sequence of linking metadata entries |
+
+A `linking_entry` is:
+
+| Field    | Type                | Description                     |
+| -------- | ------------------- | ------------------------------- |
+| type     | `varuint32`         | the linking metadata entry type |
+
+A linking metadata entry type can be one of the following:
+
+- `0 / R_WEBASSEMBLY_STACK_POINTER` - This specifies which global
+  variable is to be treated as the stack pointer.
+
+For `R_WEBASSEMBLY_STACK_POINTER` linking metadata entries, the following
+fields are present:
+
+| Field  | Type             | Description                         |
+| ------ | ---------------- | ----------------------------------- |
+| index  | `varuint32`      | index of the global which is the stack pointer |
+
 Merging Global Section
 ----------------------
 
 Merging of globals sections requires re-numbering of the globals.
 
-This convention requires the first global in the global section to be a mutable
-i32 global initialized to "STACKTOP" in the "env" module. During linking, only
-one of these globals is kept, and it remains the first global. This is a
-simple convention which allows code to reference global `0` without needing to
-be rewritten.
+The global identified in the linking metadata section as the stack pointer is
+handled specially. During linking, only one of these globals is kept, and all
+references to stack-pointer globals are rewritten to use it.
 
 Merging Function Sections
 -------------------------

--- a/Linking.md
+++ b/Linking.md
@@ -68,6 +68,8 @@ A relocation type can be one of the following:
 - `5 / R_WEBASSEMBLY_MEMORY_ADDR_I32` - a linear memory index encoded as a
   [uint32], e.g. taking the address of a C++ global in a static data
   initializer.
+- `6 / R_WEBASSEMBLY_TYPE_INDEX_LEB` - a type table index encoded as a
+  5-byte [varuint32], e.g. the type immediate in a `call_indirect`.
 
 [varuint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varuintn
 [varint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varintn
@@ -91,6 +93,14 @@ present:
 | offset | `varuint32`      | offset of the value to rewrite      |
 | index  | `varuint32`      | the index of the global used        |
 | addend | `varint32`       | addend to add to the address        |
+
+For `R_WEBASSEMBLY_TYPE_INDEX_LEB` relocations the following fields are
+present:
+
+| Field  | Type             | Description                         |
+| ------ | ---------------- | ----------------------------------- |
+| offset | `varuint32`      | offset of the value to rewrite      |
+| index  | `varuint32`      | the index of the type used          |
 
 Merging Global Section
 ----------------------


### PR DESCRIPTION
Because we want to be able to write C++ global addresses into the data section,
we can't count on using a get_global to read the value of an imported global to
get the C++ global address. In view of that, and the fact that it's also simpler
to write addresses directly into the code section than use an actual get_global,
drop the get_globals altogether. This results in several changes to the
relocations.

And, add an addend field to C++ global address relocations. I think this ends
up making sense because it makes sense for the addend to be signed, but some of
the relocations apply to fields which are unsigned, so storing the addend in them
is awkward.

LLVM isn't quite finished implementing the stack pointer part of this, and as I wrote this up, I also realized that it's missing support for relocating type indices in `call_indirect` instructions, however I'm posting it now so that we can start talking about the other parts.