### PR TITLE
Add a comment about the motivation for WASM_DATA_SIZE.

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -145,6 +145,9 @@ The current list of valid `type` codes are:
 
 - `2 / WASM_DATA_SIZE` - Specifies the total size of the static data used by the
   module, including both initialized and zero-initialized (bss) data.
+  Note that this is similar to the "minimum" field in the linear memory
+  description, however it's in units of bytes, so it's not limited to being
+  a multiple of the page size.
 
 - `3 / WASM_DATA_ALIGNMENT` - Specifies the alignment of the data section.  This
   tells the linking what constraints are placed on the location of the data


### PR DESCRIPTION
Add new linking metadata types for memory and tables.

Also, remove WASM_DATA_SIZE, which is redundant with the "minimum" field
of the linear memory description.

This documents the changes proposed in LLVM patch [D40875](https://reviews.llvm.org/D40875).

I'm not attached to most of the particular details here; my main interest is in switching to imports for memory and tables.
