### PR TITLE
Add initial ProducersSection.md

### DIFF
--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -14,7 +14,7 @@ the section or include themselves in an existing section by default, keeping
 the producers section even in release builds.
 
 An additional goal of the producers section is to provide a discrete, but
-easily-growable [list of known tools/languages/SDKs](#known-list) for each
+easily-growable [list of known tools/languages](#known-list) for each
 record field. This avoids the skew that otherwise happens with unstructured
 strings. Unknown names do not invalidate an otherwise-valid producers section.
 However, wasm consumers may provide less accurate telemetry results for unknown
@@ -45,7 +45,7 @@ where a `field` is encoded as:
 | ----------------- | ---- | ----------- |
 | field_name        | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | name of this field |
 | field_value_count | `varuint32` | number of value strings that follow |
-| field_values      | `versioned-name*` | sequence of `value_count` value strings |
+| field_values      | `versioned-name*` | sequence of `field_value_count` name-value pairs |
 
 where a `versioned-name` is encoded as:
 
@@ -56,10 +56,10 @@ where a `versioned-name` is encoded as:
 
 with the additional constraint that each field_name in the list must be unique
 and found in the first column of the following table, and each of a given field_name's
-field_values's `name` strings must be unique and found in the second column of
+field_values's name strings must be unique and found in the second column of
 the field_name's row.
 
-| field_name     | field_values strings |
+| field_name     | field_value name strings |
 | -------------- | -------------------- |
 | `language`     | [source language list](#source-languages) |
 | `processed-by` | [individual tool list](#individual-tools) |

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -8,20 +8,21 @@ producers and consumers.
 
 The producers section is a
 [custom section](https://webassembly.github.io/spec/core/binary/modules.html#custom-section)
-and thus has no behavior effect and can be stripped at any time.
-However, the producers it is intended to be small and thus the intention is
-that tools include themselves in the toolchain section by default for the
-benefit of downstream analysis.
+and thus has no semantic effects and can be stripped at any time.
+Since the producers section is relatively small, tools are encouraged to emit
+the section or include themselves in an existing section by default, keeping
+the producers section even in release builds.
 
 An additional goal of the producers section is to provide a discrete, but
-easily-growable list of known values for each record field. This avoids
-the normal skew that happens with completely unstructured strings. WebAssembly
+easily-growable [list of known tools](#known-tools) for each record field. This
+avoids the skew that otherwise happens with unstructured strings. WebAssembly
 consumers are encouraged to emit diagnostics when given values that don't match
-the list which encourage producers to register new field values in this document.
+the known tools list to encourage producers to register new field values in this
+document.
 
 Since version information is useful but highly-variable, every field value is
-optionally suffixed with a parenthesized version string, which is not matched
-against any list and thus does not diagnostic validity checking.
+optionally suffixed with a parenthesized version string which is not validated
+against any list.
 
 # Known tools
 

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -15,11 +15,10 @@ the producers section even in release builds.
 
 An additional goal of the producers section is to provide a discrete, but
 easily-growable [list of known tools](#known-tools) for each record field. This
-avoids the skew that otherwise happens with unstructured strings. Evergreen
-WebAssembly consumers (like browsers) are encourage to emit diagnostics
-encouraging producers to register new field values in this document. However, an
-unknown tool does not make the producers section invalid and all consumers
-should gracefully handle unknown tool names.
+avoids the skew that otherwise happens with unstructured strings. Unknown tools
+do not invalidate an otherwise-valid producers section. However, wasm consumers
+may provide less accurate telemetry results for unknown tools or even emit
+diagnostics encouraging the tool to be put on the list.
 
 Since version information is useful but highly-variable, every field value is
 optionally suffixed with a parenthesized version string which is not checked

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -56,7 +56,7 @@ validity constraints on the UTF-8-decoded code points of these strings.
 ## Tool name string
 
 A tool name is a sequence of code points containing anything *other* than
-parentheses and commas, allowing the simple scanning of compound patterns.
+parentheses and commas.
 
 JS Pattern: `/[^(),]+/`
 
@@ -92,7 +92,7 @@ Example tool-version strings:
 
 ## Tool-version set string
 
-A tool-version set string is possibly-empty, comma-deliminted list where each
+A tool-version set string a is possibly-empty, comma-delimited list where each
 contained tool name string is unique.
 
 Pattern (ignoring uniqueness requirement):
@@ -106,7 +106,7 @@ Example tool-version set strings:
 
 # Custom Section
 
-Custom section `name` field: `"producers"`
+Custom section `name` field: `producers`
 
 The producers section may appear only once, and only after the
 [Name section](https://webassembly.github.io/spec/core/appendix/custom.html#name-section).

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -37,7 +37,7 @@ end of the last field must coincide with the last byte of the producers section:
 | Field       | Type        | Description |
 | ----------- | ----------- | ----------- |
 | field_count | `varuint32` | number of fields that follow |
-| fields      | `field*`     | sequence of `field_count` `field` records |
+| fields      | `field*`     | sequence of field_count `field` records |
 
 where a `field` is encoded as:
 
@@ -45,7 +45,7 @@ where a `field` is encoded as:
 | ----------------- | ---- | ----------- |
 | field_name        | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | name of this field |
 | field_value_count | `varuint32` | number of value strings that follow |
-| field_values      | `versioned-name*` | sequence of `field_value_count` name-value pairs |
+| field_values      | `versioned-name*` | sequence of field_value_count name-value pairs |
 
 where a `versioned-name` is encoded as:
 

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -29,7 +29,7 @@ Since version information is useful, but highly-variable, each field value
 is accompanied with a version string so that the name can remain stable
 over time without requiring frequent updates to the known list.
 
-# Custom Section
+## Custom Section
 
 Custom section `name` field: `producers`
 
@@ -42,13 +42,13 @@ end of the last field must coincide with the last byte of the producers section:
 | Field       | Type        | Description |
 | ----------- | ----------- | ----------- |
 | field_count | `varuint32` | number of fields that follow |
-| fields      | `field*`     | sequence of field_count `field` records |
+| fields      | `field*`    | sequence of field_count `field` records |
 
 where a `field` is encoded as:
 
 | Field             | Type | Description |
 | ----------------- | ---- | ----------- |
-| field_name        | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | name of this field |
+| field_name        | [name][name-ref] | name of this field |
 | field_value_count | `varuint32` | number of value strings that follow |
 | field_values      | `versioned-name*` | sequence of field_value_count name-value pairs |
 
@@ -56,8 +56,8 @@ where a `versioned-name` is encoded as:
 
 | Field   | Type | Description |
 | ------- | ---- | ----------- |
-| name    | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | name of the language/tool |
-| version | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | version of the language/tool |
+| name    | [name][name-ref] | name of the language/tool |
+| version | [name][name-ref] | version of the language/tool |
 
 with the additional constraint that each field_name in the list must be unique
 and found in the first column of the following table, and each of a given field_name's
@@ -68,18 +68,20 @@ the field_name's row.
 | -------------- | -------------------- |
 | `language`     | [source language list](#source-languages) |
 | `processed-by` | [individual tool list](#individual-tools) |
-| `sdk`          | [SDK list](#sdks) |
+| `sdk`          | [SDK list](#sdks)    |
 
-# Text format
+[name-ref]: https://webassembly.github.io/spec/core/binary/values.html#names
+
+## Text format
 
 TODO
 
-# Known list
+## Known list
 
 The following lists contain all the known names for the fields listed above.
 **If your tool is not on this list and you'd like it to be, please submit a PR.**
 
-## Source Languages
+### Source Languages
 
 It is possible for multiple source languages to be present in a single module
 when the output of multiple compiled languages are statically linked together.
@@ -88,7 +90,7 @@ when the output of multiple compiled languages are statically linked together.
 * `C`
 * `C++`
 
-## Individual Tools
+### Individual Tools
 
 It is possible (and common) for multiple tools to be used in the overall
 pipeline that produces and optimizes a given wasm module.
@@ -98,11 +100,10 @@ pipeline that produces and optimizes a given wasm module.
 * `lld`
 * `Binaryen`
 
-## SDKs
+### SDKs
 
 While an SDK is technically just another tool, the `sdk` field designates the
 top-level "thing" that the developer installs and interacts with directly to
 produce the wasm module.
 
 * `Emscripten`
-

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -15,14 +15,15 @@ the producers section even in release builds.
 
 An additional goal of the producers section is to provide a discrete, but
 easily-growable [list of known tools](#known-tools) for each record field. This
-avoids the skew that otherwise happens with unstructured strings. WebAssembly
-consumers are encouraged to emit diagnostics when given values that don't match
-the known tools list to encourage producers to register new field values in this
-document.
+avoids the skew that otherwise happens with unstructured strings. Evergreen
+WebAssembly consumers (like browsers) are encourage to emit diagnostics
+encouraging producers to register new field values in this document. However, an
+unknown tool does not make the producers section invalid and all consumers
+should gracefully handle unknown tool names.
 
 Since version information is useful but highly-variable, every field value is
-optionally suffixed with a parenthesized version string which is not validated
-against any list.
+optionally suffixed with a parenthesized version string which is not checked
+against any known list.
 
 # Known tools
 

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -27,7 +27,7 @@ against any known list.
 
 # Known tools
 
-The following lists contain all the valid tool names for the fields listed below.
+The following lists contain all the known tool names for the fields listed below.
 **If your tool is not on this list and you'd like it to be, please submit a PR.**
 
 ## Source Languages

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -53,10 +53,11 @@ The binary encoding of record fields uses the standard
 used elsewhere in wasm modules. However, the producers section imposes additional
 validity constraints on the UTF-8-decoded code points of these strings.
 
-## Tool name string
+## Atom
 
-A tool name is a sequence of code points containing anything *other* than
-parentheses and commas.
+An "atom" is a sequence of code points containing anything *other* than
+parentheses and commas (which are the only relevant separators in producer
+section strings).
 
 JS Pattern: `/[^(),]+/`
 
@@ -65,30 +66,19 @@ Example tool name strings:
 * c++
 * ☃
 
-## Version string
-
-A version string can be appended to any tool name and describes the version of
-that tool.
-
-JS Pattern: `/\((\d+\.)*\d*\)/`
-
-Example version strings:
-* (1)
-* (1.2)
-* (0.12.1.30)
-
 ## Tool-version string
 
-A tool-version string is a tool name string followed by an optional version string.
+A tool-version string is an atom identifying the tool name followed by
+an optional parenthesized atom identifying the version.
 
 Pattern:
-* Logical: `Tool name string` `Version string`?
-* JS: `/[^(),]+(\((\d+\.)*\d*\))?/`
+* Logical: [`Atom`](#atom) ( `(` [`Atom`](#atom) `)` )?
+* JS: `/[^(),]+(\([^(),]*\))?/`
 
 Example tool-version strings:
 * a
 * c++(11)
-* ☃(0.0.1)
+* ☃(1.0.☃)
 
 ## Tool-version set string
 
@@ -96,13 +86,13 @@ A tool-version set string a is possibly-empty, comma-delimited list where each
 contained tool name string is unique.
 
 Pattern (ignoring uniqueness requirement):
-* Logical: ( `Tool-version string` `,` )* `Tool-version string`
-* JS: `/([^(),]+(\((\d+\.)*\d*\))?,)*[^(),]+(\((\d+\.)*\d*\))?/`
+* Logical: ( [`Tool-version string`](#tool-version-string) `,` )* [`Tool-version string`](#tool-version-string)
+* JS: `/([^(),]+(\([^(),]*\))?,)*[^(),]+(\([^(),]*\))?/`
 
 Example tool-version set strings:
 * a
 * a(1.0)
-* llvm(20.3),binaryen,lld(1.3),webpack(4)
+* llvm(20.3-beta),binaryen,lld(1.3),webpack(4)
 
 # Custom Section
 

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -18,11 +18,11 @@ easily-growable [list of known tools/languages/SDKs](#known-list) for each
 record field. This avoids the skew that otherwise happens with unstructured
 strings. Unknown names do not invalidate an otherwise-valid producers section.
 However, wasm consumers may provide less accurate telemetry results for unknown
-names or even emit diagnostics encouraging the name to be put on [the list](#known-list).
+names or even emit diagnostics encouraging the name to be put on the known list.
 
 Since version information is useful, but highly-variable, each field value
 is accompanied with a version string so that the name can remain stable
-over time without requiring frequent updates to the [known list](#known-list).
+over time without requiring frequent updates to the known list.
 
 # Custom Section
 

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -72,10 +72,6 @@ the field_name's row.
 
 [name-ref]: https://webassembly.github.io/spec/core/binary/values.html#names
 
-## Text format
-
-TODO
-
 ## Known list
 
 The following lists contain all the known names for the fields listed above.
@@ -107,3 +103,7 @@ top-level "thing" that the developer installs and interacts with directly to
 produce the wasm module.
 
 * `Emscripten`
+
+## Text format
+
+TODO

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -82,7 +82,7 @@ Example tool-version strings:
 
 ## Tool-version set string
 
-A tool-version set string a is possibly-empty, comma-delimited list where each
+A tool-version set string is a possibly-empty, comma-delimited list where each
 contained tool name string is unique.
 
 Pattern (ignoring uniqueness requirement):

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -1,0 +1,138 @@
+# Producers Section
+
+The purpose of the producers section is to provide an optional,
+highly-structured record of all the distinct tools that were used to produce
+a given WebAssembly module. A primary purpose of this record is to allow
+broad analysis of toolchain usage in the wild, which can help inform both wasm
+producers and consumers.
+
+The producers section is a
+[custom section](https://webassembly.github.io/spec/core/binary/modules.html#custom-section)
+and thus has no behavior effect and can be stripped at any time.
+However, the producers it is intended to be small and thus the intention is
+that tools include themselves in the toolchain section by default for the
+benefit of downstream analysis.
+
+An additional goal of the producers section is to provide a discrete, but
+easily-growable list of known values for each record field. This avoids
+the normal skew that happens with completely unstructured strings. WebAssembly
+consumers are encouraged to emit diagnostics when given values that don't match
+the list which encourage producers to register new field values in this document.
+
+Since version information is useful but highly-variable, every field value is
+optionally suffixed with a parenthesized version string, which is not matched
+against any list and thus does not diagnostic validity checking.
+
+# Known tools
+
+The following lists contain all the valid tool names for the fields listed below.
+**If your tool is not on this list and you'd like it to be, please submit a PR.**
+
+## Source Languages
+
+* `wat`
+* `C`
+* `C++`
+
+## Individual Tools
+
+* `wabt`
+* `llvm`
+* `lld`
+* `Binaryen`
+
+## SDKs
+
+* `Emscripten`
+
+# String formats
+
+The binary encoding of record fields uses the standard
+[name encoding](https://webassembly.github.io/spec/core/binary/values.html#names)
+used elsewhere in wasm modules. However, the producers section imposes additional
+validity constraints on the UTF-8-decoded code points of these strings.
+
+## Tool name string
+
+A tool name is a sequence of code points containing anything *other* than
+parentheses and commas, allowing the simple scanning of compound patterns.
+
+JS Pattern: `/[^(),]+/`
+
+Example tool name strings:
+* wabt
+* c++
+* ☃
+
+## Version string
+
+A version string can be appended to any tool name and describes the version of
+that tool.
+
+JS Pattern: `/\((\d+\.)*\d*\)/`
+
+Example version strings:
+* (1)
+* (1.2)
+* (0.12.1.30)
+
+## Tool-version string
+
+A tool-version string is a tool name string followed by an optional version string.
+
+Pattern:
+* Logical: `Tool name string` `Version string`?
+* JS: `/[^(),]+(\((\d+\.)*\d*\))?/`
+
+Example tool-version strings:
+* a
+* c++(11)
+* ☃(0.0.1)
+
+## Tool-version set string
+
+A tool-version set string is possibly-empty, comma-deliminted list where each
+contained tool name string is unique.
+
+Pattern (ignoring uniqueness requirement):
+* Logical: ( `Tool-version string` `,` )* `Tool-version string`
+* JS: `/([^(),]+(\((\d+\.)*\d*\))?,)*[^(),]+(\((\d+\.)*\d*\))?/`
+
+Example tool-version set strings:
+* a
+* a(1.0)
+* llvm(20.3),binaryen,lld(1.3),webpack(4)
+
+# Custom Section
+
+Custom section `name` field: `"producers"`
+
+The producers section may appear only once, and only after the
+[Name section](https://webassembly.github.io/spec/core/appendix/custom.html#name-section).
+
+The producers section contains a sequence of fields, where the end of the last
+field must coincide with the last byte of the producers section:
+
+| Field       | Type        | Description |
+| ----------- | ----------- | ----------- |
+| field_count | `varuint32` | number of fields that follow |
+| fields      | `field*`     | sequence of `field` |
+
+where a `field` is encoded as:
+
+| Field       | Type | Description |
+| ----------- | ---- | ----------- |
+| field_name  | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | name of this field, chosen from one of the set of valid field names below |
+| field_value | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | a string which match the specified pattern according to the table below |
+
+The valid field names and their associated patterns are:
+
+| field_name     | field_value pattern  | Valid tool names |
+| -------------- | -------------------- | --------- |
+| `language`     | [Tool-version string](#tool-version-string) | [source language list](#source-languages) |
+| `processed-by` | [Tool-version set string](#tool-version-set-string) | [individual tool list](#individual-tools) |
+| `sdk`          | [Tool-version string](#tool-version-string) | [SDK list](#sdks) |
+
+# Text format
+
+TODO

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -102,8 +102,8 @@ Custom section `name` field: `producers`
 The producers section may appear only once, and only after the
 [Name section](https://webassembly.github.io/spec/core/appendix/custom.html#name-section).
 
-The producers section contains a sequence of fields, where the end of the last
-field must coincide with the last byte of the producers section:
+The producers section contains a sequence of fields with unique names, where the
+end of the last field must coincide with the last byte of the producers section:
 
 | Field       | Type        | Description |
 | ----------- | ----------- | ----------- |
@@ -117,7 +117,7 @@ where a `field` is encoded as:
 | field_name  | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | name of this field, chosen from one of the set of valid field names below |
 | field_value | [name](https://webassembly.github.io/spec/core/binary/values.html#names) | a string which match the specified pattern according to the table below |
 
-The valid field names and their associated patterns are:
+Each field_name in the list must be unique and found in the folowing table:
 
 | field_name     | field_value pattern  | Valid tool names |
 | -------------- | -------------------- | --------- |

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -13,6 +13,11 @@ Since the producers section is relatively small, tools are encouraged to emit
 the section or include themselves in an existing section by default, keeping
 the producers section even in release builds.
 
+WebAssembly consumers should avoid using the producers section to derive
+optimization hints. To ensure portable performance, hints should be
+standardized in a separate custom section, probably in the core spec's
+[Custom Sections appendix](https://webassembly.github.io/spec/core/appendix/custom.html).
+
 An additional goal of the producers section is to provide a discrete, but
 easily-growable [list of known tools/languages](#known-list) for each
 record field. This avoids the skew that otherwise happens with unstructured

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -39,7 +39,7 @@ The following lists contain all the known tool names for the fields listed below
 ## Individual Tools
 
 * `wabt`
-* `llvm`
+* `LLVM`
 * `lld`
 * `Binaryen`
 


### PR DESCRIPTION
As discussed in #63.  Feedback and suggestions welcome.

In the "Known tools" lists, I intentionally included the bare-minimum which @dschuff and team can review.  After the initial PR merges, I'd expect Rust, Blazor, etc to file PRs, adding the tool names that make sense to them.

I think we should also introduce some custom .wat syntax for this custom section, but I'd like to see some agreement on the fundamental fields, as proposed in the binary format, before adding that, so I left this as TODO in this PR.

If anyone wants to implement a producer of this section, I'd be more than happy to validate the output in SpiderMonkey by implementing a consumer; just ping me.