### PR TITLE
Add some Rust-specific values to producers sections

### DIFF
--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -85,6 +85,7 @@ when the output of multiple compiled languages are statically linked together.
 * `wat`
 * `C`
 * `C++`
+* `Rust`
 
 ### Individual Tools
 
@@ -95,6 +96,9 @@ pipeline that produces and optimizes a given wasm module.
 * `LLVM`
 * `lld`
 * `Binaryen`
+* `rustc`
+* `wasm-bindgen`
+* `wasm-pack`
 
 ### SDKs
 


### PR DESCRIPTION
Add a `Rust` language value where the "version" will likely be the
edition of the Rust code (2015 or 2018 today), and add the tools of
`rustc`, `wasm-bindgen`, and `wasm-pack`.