### PR TITLE
Fundamental scalar types

### DIFF
--- a/BasicCABI.md
+++ b/BasicCABI.md
@@ -8,6 +8,10 @@ compiler wishing to be ABI-compatible with it.
 
 **Scalar Types**
 
+The ABI for the currently-specifed version of WebAssembly (also known as "wasm32") uses an "ILP32" data model, 
+where `int`, `long`, and pointer types are 32 bits. It is expected that the proposed extension to allow memories
+larger than 4GB ("wasm64") will use an "LP64" data model, where `int` and `long` are 64 bits.
+
 The following table shows the memory sizes and alignments of C and C++ scalar types, and their
 correspondence to types used in the WebAssembly specification:
 
@@ -15,7 +19,7 @@ correspondence to types used in the WebAssembly specification:
 General type | C Type | `sizeof` | Alignment (bytes) | Wasm Value Type
 -|-|-|-|-
  Integer | `_Bool`/`bool` | 1 | 1 | i32
- Integer | `char`/`signed char` | 1 | 1 | i | i32
+ Integer | `char`, `signed char` | 1 | 1 | i | i32
  Integer | `unsigned char` | 1 | 1 | i32
  Integer | `short` / `signed short` | 2 | 2 | i32
  Integer | `unsigned short` | 2 | 2 | i32
@@ -25,18 +29,14 @@ General type | C Type | `sizeof` | Alignment (bytes) | Wasm Value Type
  Integer | `unsigned long` | 4 | 4 | i32
  Integer | `long long` / `signed long long` | 8 | 8 | i64
  Integer | `unsigned long long` | 8 | 8 | i64
- Pointer | `any-type *` / `any-type (*)()` | 4 | 4 | i32
+ Pointer | *`any-type *`* / *`any-type (*)()`* | 4 | 4 | i32
  Floating point | `float` | 4 | 4 | f32
  Floating point | `double` | 8 | 8 | f64
  Floating point | `long double` | 16 | 16 | (none)
  
- * `long double` values correspond to IEEE-754 128-bit extended values, but they are represented
- as a pair if f64 values, and operations on these values are currently implemented as calls to
+ * `long double` values correspond to 128-bit quad-precision values, but they are represented
+ as a pair of f64 values, and operations on these values are currently implemented as calls to
  compiler-rt library functions.
  * A null pointer (for all types) has the value zero
  * The `size_t` type is defined as `unsigned long`.
- * Booleans, when stored in a memory object, are stored as a single byte, thevalue of which is always 0
- (false) or 1 (true). When stored in local wasm values (locals, stack values), 
-(except for passing as arguments), all 4 bytes are significant; any nonzero value is considered true.
- * Wasm does not require that all data accesses be aligned, but they may be significantly slower.
-
+ 

--- a/BasicCABI.md
+++ b/BasicCABI.md
@@ -34,8 +34,8 @@ General type | C Type | `sizeof` | Alignment (bytes) | Wasm Value Type
  Floating point | `double` | 8 | 8 | f64
  Floating point | `long double` | 16 | 16 | (none)
  
- * `long double` values correspond to 128-bit quad-precision values, but they are represented
- as a pair of f64 values, and operations on these values are currently implemented as calls to
+ * `long double` values correspond to 128-bit IEEE-754 quad-precision binary128 values.
+ Operations on these values are currently implemented as calls to
  compiler-rt library functions.
  * A null pointer (for all types) has the value zero
  * The `size_t` type is defined as `unsigned long`.

--- a/BasicCABI.md
+++ b/BasicCABI.md
@@ -19,7 +19,7 @@ correspondence to types used in the WebAssembly specification:
 General type | C Type | `sizeof` | Alignment (bytes) | Wasm Value Type
 -|-|-|-|-
  Integer | `_Bool`/`bool` | 1 | 1 | i32
- Integer | `char`, `signed char` | 1 | 1 | i | i32
+ Integer | `char`, `signed char` | 1 | 1 | i32
  Integer | `unsigned char` | 1 | 1 | i32
  Integer | `short` / `signed short` | 2 | 2 | i32
  Integer | `unsigned short` | 2 | 2 | i32

--- a/BasicCABI.md
+++ b/BasicCABI.md
@@ -3,14 +3,40 @@ This document describes the "Basic" C ABI for WebAssembly. As mentioned in
 clang/LLVM WebAssembly backend is currently using, and any other C or C++
 compiler wishing to be ABI-compatible with it.
 
-wasm32 is ILP32 and wasm64 is LP64. `float` and `double` map to wasm’s `f32` and
-`f64` respectively.  Varargs is lowered to passing a pointer to an
-explicitly-allocated buffer.  Single-element struct return values are returned
-by a normal wasm return value. TODO: Spell this all out in much more detail.
 
-This is just an initial sketch of some content. Obviously, it would be desirable
-to go into a lot more detail.
+## Data Representation
 
-Eventually, some content from the design repo's
-[CAndC++](https://github.com/WebAssembly/design/blob/master/CAndC++.md) should also
-be moved here.
+**Scalar Types**
+
+The following table shows the memory sizes and alignments of C and C++ scalar types, and their
+correspondence to types used in the WebAssembly specification:
+
+
+General type | C Type | `sizeof` | Alignment (bytes) | Wasm Value Type
+-|-|-|-|-
+ Integer | `_Bool`/`bool` | 1 | 1 | i32
+ Integer | `char`/`signed char` | 1 | 1 | i | i32
+ Integer | `unsigned char` | 1 | 1 | i32
+ Integer | `short` / `signed short` | 2 | 2 | i32
+ Integer | `unsigned short` | 2 | 2 | i32
+ Integer | `int` / `signed int` / `enum` | 4 | 4 | i32
+ Integer | `unsigned int` | 4 | 4 | i32
+ Integer | `long` / `signed long` | 4 | 4 | i32
+ Integer | `unsigned long` | 4 | 4 | i32
+ Integer | `long long` / `signed long long` | 8 | 8 | i64
+ Integer | `unsigned long long` | 8 | 8 | i64
+ Pointer | `any-type *` / `any-type (*)()` | 4 | 4 | i32
+ Floating point | `float` | 4 | 4 | f32
+ Floating point | `double` | 8 | 8 | f64
+ Floating point | `long double` | 16 | 16 | (none)
+ 
+ * `long double` values correspond to IEEE-754 128-bit extended values, but they are represented
+ as a pair if f64 values, and operations on these values are currently implemented as calls to
+ compiler-rt library functions.
+ * A null pointer (for all types) has the value zero
+ * The `size_t` type is defined as `unsigned long`.
+ * Booleans, when stored in a memory object, are stored as a single byte, thevalue of which is always 0
+ (false) or 1 (true). When stored in local wasm values (locals, stack values), 
+(except for passing as arguments), all 4 bytes are significant; any nonzero value is considered true.
+ * Wasm does not require that all data accesses be aligned, but they may be significantly slower.
+


### PR DESCRIPTION
This begins documenting the C ABI. For now I've started with the format used by the x86-64 sysV ABI, but for now the format is less important since I want to get through as much as we can before the LLVM branch.