### PR TITLE
Add Webpack/webassemblyjs in producers

### DIFF
--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -100,6 +100,7 @@ pipeline that produces and optimizes a given wasm module.
 * `rustc`
 * `wasm-bindgen`
 * `wasm-pack`
+* `webassemblyjs`
 
 ### SDKs
 
@@ -108,6 +109,7 @@ top-level "thing" that the developer installs and interacts with directly to
 produce the wasm module.
 
 * `Emscripten`
+* `Webpack`
 
 ## Text format
 


### PR DESCRIPTION
While `Webpack` is not a SDK, it conforms with the description
> designates the top-level "thing" that the developer installs and interacts with directly to produce the wasm module

For ref https://github.com/webpack/webpack/issues/8429

`webassemblyjs` is the underlying tool that Webpack uses.