### PR TITLE
Rename relocations from R_WEBASSEMBLY_ to R_WASM_

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -60,36 +60,36 @@ A `relocation_entry` begins with:
 | -------- | ------------------- | ------------------------------ |
 | type     | `uint8`             | the relocation type            |
 | offset   | `varuint32`         | offset of the value to rewrite |
-| index    | `varuint32`         | the index of the symbol used (or, for `R_WEBASSEMBLY_TYPE_INDEX_LEB` relocations, the index of the type) |
+| index    | `varuint32`         | the index of the symbol used (or, for `R_WASM_TYPE_INDEX_LEB` relocations, the index of the type) |
 
 A relocation type can be one of the following:
 
-- `0 / R_WEBASSEMBLY_FUNCTION_INDEX_LEB` - a function index encoded as a 5-byte
+- `0 / R_WASM_FUNCTION_INDEX_LEB` - a function index encoded as a 5-byte
   [varuint32]. Used for the immediate argument of a `call` instruction.
-- `1 / R_WEBASSEMBLY_TABLE_INDEX_SLEB` - a function table index encoded as a
+- `1 / R_WASM_TABLE_INDEX_SLEB` - a function table index encoded as a
   5-byte [varint32]. Used to refer to the immediate argument of a `i32.const`
   instruction, e.g. taking the address of a function.
-- `2 / R_WEBASSEMBLY_TABLE_INDEX_I32` - a function table index encoded as a
+- `2 / R_WASM_TABLE_INDEX_I32` - a function table index encoded as a
   [uint32], e.g. taking the address of a function in a static data initializer.
-- `3 / R_WEBASSEMBLY_MEMORY_ADDR_LEB` - a linear memory index encoded as a 5-byte
+- `3 / R_WASM_MEMORY_ADDR_LEB` - a linear memory index encoded as a 5-byte
   [varuint32]. Used for the immediate argument of a `load` or `store`
   instruction, e.g. directly loading from or storing to a C++ global.
-- `4 / R_WEBASSEMBLY_MEMORY_ADDR_SLEB` - a linear memory index encoded as a 5-byte
+- `4 / R_WASM_MEMORY_ADDR_SLEB` - a linear memory index encoded as a 5-byte
   [varint32]. Used for the immediate argument of a `i32.const` instruction,
   e.g. taking the address of a C++ global.
-- `5 / R_WEBASSEMBLY_MEMORY_ADDR_I32` - a linear memory index encoded as a
+- `5 / R_WASM_MEMORY_ADDR_I32` - a linear memory index encoded as a
   [uint32], e.g. taking the address of a C++ global in a static data
   initializer.
-- `6 / R_WEBASSEMBLY_TYPE_INDEX_LEB` - a type table index encoded as a
+- `6 / R_WASM_TYPE_INDEX_LEB` - a type table index encoded as a
   5-byte [varuint32], e.g. the type immediate in a `call_indirect`.
-- `7 / R_WEBASSEMBLY_GLOBAL_INDEX_LEB` - a global index encoded as a
+- `7 / R_WASM_GLOBAL_INDEX_LEB` - a global index encoded as a
   5-byte [varuint32], e.g. the index immediate in a `get_global`.
-- `8 / R_WEBASSEMBLY_FUNCTION_OFFSET_I32` - a byte offset within code section
+- `8 / R_WASM_FUNCTION_OFFSET_I32` - a byte offset within code section
   for the specic function encoded as a [uint32].
   The offsets start at the actual function code excluding its size field.
-- `9 / R_WEBASSEMBLY_SECTION_OFFSET_I32` - an byte offset from start of the
+- `9 / R_WASM_SECTION_OFFSET_I32` - an byte offset from start of the
   specified section encoded as a [uint32].
-- `10 / R_WEBASSEMBLY_EVENT_INDEX_LEB` - an event index encoded as a 5-byte
+- `10 / R_WASM_EVENT_INDEX_LEB` - an event index encoded as a 5-byte
   [varuint32]. Used for the immediate argument of a `throw` and `if_except`
   instruction.
 
@@ -97,10 +97,10 @@ A relocation type can be one of the following:
 [varint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varintn
 [uint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#uintn
 
-For `R_WEBASSEMBLY_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB`,
-`R_WEBASSEMBLY_MEMORY_ADDR_I32`, `R_WEBASSEMBLY_FUNCTION_OFFSET_I32`,
-and `R_WEBASSEMBLY_SECTION_OFFSET_I32` relocations the following field is
-additionally present:
+For `R_WASM_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB`,
+`R_WASM_MEMORY_ADDR_I32`, `R_WEBASSEMBLY_FUNCTION_OFFSET_I32`, and
+`R_WASM_SECTION_OFFSET_I32` relocations the following field is additionally
+present:
 
 | Field  | Type             | Description                         |
 | ------ | ---------------- | ----------------------------------- |
@@ -331,11 +331,11 @@ stored in the code section:
 2. Immediate argument of the `i32.const` instruction (taking the address of a
    function).
 
-The immediate argument of all such instructions are stored as padded LEB128
-such that they can be rewritten without altering the size of the code section.
-For each such instruction a `R_WEBASSEMBLY_FUNCTION_INDEX_LEB` or
-`R_WEBASSEMBLY_TABLE_INDEX_SLEB` `reloc` entry is generated pointing to the
-offset of the immediate within the code section.
+The immediate argument of all such instructions are stored as padded LEB128 such
+that they can be rewritten without altering the size of the code section.  For
+each such instruction a `R_WASM_FUNCTION_INDEX_LEB` or `R_WASM_TABLE_INDEX_SLEB`
+`reloc` entry is generated pointing to the offset of the immediate within the
+code section.
 
 The same technique applies for all function calls whether the function is
 imported or defined locally.
@@ -360,9 +360,9 @@ section.
 
 The output data section is formed, essentially, by concatenating the data
 sections of the input files.  Since the final location in linear memory of any
-given symbol is not known until link time, all references to data addresses
-with the code and data sections generate `R_WEBASSEMBLY_MEMORY_ADDR_*`
-relocation entries, which reference a data symbol.
+given symbol is not known until link time, all references to data addresses with
+the code and data sections generate `R_WASM_MEMORY_ADDR_*` relocation entries,
+which reference a data symbol.
 
 Segments are linked as a whole, and a segment is either entirely included or
 excluded from the link.
@@ -381,11 +381,11 @@ Processing Relocations
 
 The final code and data sections are written out with relocations applied.
 
-`R_WEBASSEMBLY_TYPE_INDEX_LEB` relocations cannot fail.  The output Wasm file
+`R_WASM_TYPE_INDEX_LEB` relocations cannot fail.  The output Wasm file
 shall contain a newly-synthesised type section which contains entries for all
 functions and type relocations in the output.
 
-`R_WEBASSEMBLY_TABLE_INDEX_SLEB` and `R_WEBASSEMBLY_TABLE_INDEX_I32` relocations
+`R_WASM_TABLE_INDEX_SLEB` and `R_WEBASSEMBLY_TABLE_INDEX_I32` relocations
 cannot fail.  The output Wasm file shall contain a newly-synthesised table,
 which contains an entry for all defined or imported symbols referenced by table
 relocations.  The output table elements shall begin at a non-zero offset within
@@ -394,32 +394,32 @@ Finally, when processing table relocations for symbols which have neither an
 import nor a definition (namely, weakly-undefined function symbols), the value
 `0` is written out as the value of the relocation.
 
-`R_WEBASSEMBLY_FUNCTION_INDEX_LEB` relocations may fail to be processed, in
+`R_WASM_FUNCTION_INDEX_LEB` relocations may fail to be processed, in
 which case linking fails.  This occurs if there is a weakly-undefined function
 symbol, in which case there is no legal value that can be written as the target
 of any `call` instruction.  The frontend must generate calls to undefined weak
 symbols via a `call_indirect` instruction.
 
-`R_WEBASSEMBLY_GLOBAL_INDEX_LEB` relocations may fail to be processed, in which
+`R_WASM_GLOBAL_INDEX_LEB` relocations may fail to be processed, in which
 case linking fails.  This occurs if there is a weakly-undefined global symbol,
 in which case there is no legal value that can be written as the target of any
 `get_global` or `set_global` instruction. (This means the frontend must not
 generate weak globals which may not be defined; a definition or import must
 exist for all global symbols in the linked output.)
 
-`R_WEBASSEMBLY_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB` and
-`R_WEBASSEMBLY_MEMORY_ADDR_I32` relocations cannot fail.  The relocation's value
+`R_WASM_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB` and
+`R_WASM_MEMORY_ADDR_I32` relocations cannot fail.  The relocation's value
 is the offset within the linear memory of the symbol within the output segment,
 plus the symbol's addend.  If the symbol is undefined (whether weak or strong),
 the value of the relocation shall be `0`.
 
-`R_WEBASSEMBLY_FUNCTION_OFFSET_I32` relocations cannot fail. The values shall be
+`R_WASM_FUNCTION_OFFSET_I32` relocations cannot fail. The values shall be
 adjusted to reflect new offsets in the code section.
 
-`R_WEBASSEMBLY_SECTION_OFFSET_I32` relocation cannot fail. The values shall be
+`R_WASM_SECTION_OFFSET_I32` relocation cannot fail. The values shall be
 adjusted to reflect new offsets in the combined sections.
 
-`R_WEBASSEMBLY_EVENT_INDEX_LEB` relocations may fail to be processed, in which
+`R_WASM_EVENT_INDEX_LEB` relocations may fail to be processed, in which
 case linking fails. This occurs if there is a weakly-undefined event symbol, in
 which case there is no legal value that can be written as the target of any
 `throw` and `if_except` instruction. (This means the frontend must not generate


### PR DESCRIPTION
This is less typing and IMHO more readable, and it also fits with
our naming around the binary format which tends to use the short name.