### PR TITLE
Document the new WASM_SYM_EXPLICIT_NAME flag.

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -207,8 +207,10 @@ For functions, globals and events, we reference an existing Wasm object, which
 is either an import or a defined function/global/event (recall that the operand of a
 Wasm `call` instruction uses an index space consisting of the function imports
 followed by the defined functions, and similarly `get_global` for global imports
-and definitions and `throw` for event imports and definitions). If a function,
-global, or event symbol references an import, then the name is taken from the
+and definitions and `throw` for event imports and definitions).
+
+If a function, global, or event symbol references an import, and the
+`WASM_SYM_EXPLICIT_NAME` flag is not set, then the name is taken from the
 import; otherwise the `syminfo` specifies the symbol's name.
 
 | Field        | Type           | Description                                 |
@@ -254,6 +256,10 @@ The current set of valid flags for symbols are:
 - `0x20 / WASM_SYM_EXPORTED` - The symbol is intended to be exported from the
   wasm module to the host environment. This differs from the visibility flags
   in that it effects the static linker.
+- `0x40 / WASM_SYM_EXPLICIT_NAME` - The symbol uses an explicit import name,
+  rather than reusing the name from a wasm import. This allows it to remap
+  imports from foreign WebAssembly modules into local symbols with different
+  names.
 
 For `WASM_COMDAT_INFO` the following fields are present in the
 subsection:

--- a/Linking.md
+++ b/Linking.md
@@ -256,7 +256,7 @@ The current set of valid flags for symbols are:
 - `0x20 / WASM_SYM_EXPORTED` - The symbol is intended to be exported from the
   wasm module to the host environment. This differs from the visibility flags
   in that it effects the static linker.
-- `0x40 / WASM_SYM_EXPLICIT_NAME` - The symbol uses an explicit import name,
+- `0x40 / WASM_SYM_EXPLICIT_NAME` - The symbol uses an explicit symbol name,
   rather than reusing the name from a wasm import. This allows it to remap
   imports from foreign WebAssembly modules into local symbols with different
   names.


### PR DESCRIPTION
This adds documentation for the `WASM_SYM_EXPLICIT_NAME` flag, added in lld r353473, and LLVM r353474 and r353476.

In short, this accompanies the new import_name attribute, which allows symbols to be declared with a wasm import name that differs from the symbol name, like this:
```c
void foo(void) __attribute__((import_module("bar"), import_name("qux")));
```
This is useful because "bar" might be a wasm module that isn't necessarily written in C and does't follow C's norms for reserved identifiers, or defines names that otherwise conflict with the importing program's names.