### PR TITLE
Target features section

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -34,6 +34,14 @@ to: e.g. "reloc.CODE" for code section relocations.  However everything after
 the period is ignored and the specific target section is encoded in the reloc
 section itself.
 
+The linker additionally checks that linked object files were built targeting
+compatible feature sets. Unlike native targets, WebAssembly has no runtime
+feature detection, and the presence of unsupported features causes a binary to
+fail to validate. It is therefore almost always a user error to link together
+object files built for different feature sets, and the linker can be helpful by
+enforcing the invariant that the feature sets must be consistent by checking
+objects' target features sections.
+
 Relocation Sections
 -------------------
 
@@ -285,6 +293,32 @@ and where a `comdat_sym` is encoded as:
 |          |                |   * `3 / WASM_COMDAT_EVENT`                 |
 | index    | `varuint32`    | Index of the data segment/function/global/event in the Wasm module (depending on kind). The function/global/event must not be an import. |
 
+Target Features Section
+-----------------------
+
+The target features section is an optional custom section with the name
+"target_features". The target features section must come after the
+["producers"](#linking-metadata-section) section.
+
+The body of the target features section is a vector of unique strings, each
+representing a feature of the target. The generally accepted feature strings
+are:
+
+1. `atomics`
+2. `bulk-memory`
+3. `exception-handling`
+4. `nontrapping-fptoint`
+5. `sign-ext`
+6. `simd128`
+
+The "atomics" feature string is special: if it is present, the linker will
+produce a binary that uses a shared memory.
+
+It is an error if two object files in a single link contain different sets of
+strings in their target features sections. Objects with no features section may
+be linked with any other objects.
+
+The linker does not emit a features section in its output.
 
 Merging Global Sections
 -----------------------
@@ -371,17 +405,6 @@ which reference a data symbol.
 
 Segments are linked as a whole, and a segment is either entirely included or
 excluded from the link.
-
-Merging Memory Sections
------------------------
-
-It is an error to link together object files with shared and unshared
-memories. Object files with unshared memories are produced by tools that are not
-aware of WebAssembly threads or are configured to produce code for a
-single-threaded environment. These objects may have been compiled from
-thread-aware source code but had their atomic operations stripped, so it would
-be dangerous to allow users to accidentally link these objects together with
-properly thread-aware objects.
 
 Merging Custom Sections
 ----------------------

--- a/Linking.md
+++ b/Linking.md
@@ -311,11 +311,12 @@ The body of the target features section is a vector of entries:
 The recognized prefix bytes and their meanings are below. When the user does not
 supply a set of allowed features explicitly, the set of allowed features is
 taken to be the set of used features. Any feature not mentioned in an object's
-target features section is not used by that object.
+target features section is not used by that object, but is not necessarily
+prohibited in the final binary.
 
 | Prefix     | Meaning |
 | ---------- | ------- |
-| 0x00       | This object uses this feature, and the link fails if this feature is not in the allowed set. |
+| 0x2b (`+`) | This object uses this feature, and the link fails if this feature is not in the allowed set. |
 | 0x2d (`-`) | This object does not use this feature, and the link fails if this feature is in the allowed set. |
 | 0x3d (`=`) | This object uses this feature, and the link fails if this feature is not in the allowed set or if any object does not use this feature. |
 

--- a/Linking.md
+++ b/Linking.md
@@ -37,10 +37,11 @@ section itself.
 The linker additionally checks that linked object files were built targeting
 compatible feature sets. Unlike native targets, WebAssembly has no runtime
 feature detection, and the presence of unsupported features causes a binary to
-fail to validate. It is therefore almost always a user error to link together
-object files built for different feature sets, and the linker can be helpful by
-enforcing the invariant that the feature sets must be consistent by checking
-objects' target features sections.
+fail to validate. It is therefore important for the user to have explicit
+control over the features used in the output binary and for the linker to
+provide helpful errors when instructed to link incompatible or disallowed
+features. This feature information is stored in a custom ["target feature
+section"](#target-features-section).
 
 Relocation Sections
 -------------------
@@ -300,9 +301,26 @@ The target features section is an optional custom section with the name
 "target_features". The target features section must come after the
 ["producers"](#linking-metadata-section) section.
 
-The body of the target features section is a vector of unique strings, each
-representing a feature of the target. The generally accepted feature strings
-are:
+The body of the target features section is a vector of entries:
+
+| Field   | Type    | Description                              |
+| ------- | ------- | ---------------------------------------- |
+| prefix  | `byte`  | See below.                               |
+| feature | `bytes` | The name of the feature. Must be unique. |
+
+The recognized prefix bytes and their meanings are below. When the user does not
+supply a set of allowed features explicitly, the set of allowed features is
+taken to be the set of used features. Any feature not mentioned in an object's
+target features section is not used by that object.
+
+| Prefix     | Meaning |
+| ---------- | ------- |
+| 0x00       | This object uses this feature, and the link fails if this feature is not in the allowed set. |
+| 0x2d (`-`) | This object does not use this feature, and the link fails if this feature is in the allowed set. |
+| 0x3d (`=`) | This object uses this feature, and the link fails if this feature is not in the allowed set or if any object does not use this feature. |
+
+unique strings, each
+representing a feature of the target. The generally accepted features are:
 
 1. `atomics`
 2. `bulk-memory`
@@ -313,12 +331,6 @@ are:
 
 The "atomics" feature string is special: if it is present, the linker will
 produce a binary that uses a shared memory.
-
-It is an error if two object files in a single link contain different sets of
-strings in their target features sections. Objects with no features section may
-be linked with any other objects.
-
-The linker does not emit a features section in its output.
 
 Merging Global Sections
 -----------------------


### PR DESCRIPTION
Adds a new "target_features" custom section that lists the features an
object was built with. It is an error to link objects with mismatched
target feature sets.

The presence of the "atomics" feature also replaces the value of the
shared bit on object file memory import as the signal to the linker
that it should use shared memory. The target features section is more
generally useful and less hacky than the old solution.