### PR TITLE
Update Producers Section to match #93

### DIFF
--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -1,33 +1,10 @@
 # Producers Section
 
-The purpose of the producers section is to provide an optional,
-highly-structured record of all the distinct tools that were used to produce
-a given WebAssembly module. A primary purpose of this record is to allow
-broad analysis of toolchain usage in the wild, which can help inform both wasm
-producers and consumers.
-
-The producers section is a
-[custom section](https://webassembly.github.io/spec/core/binary/modules.html#custom-section)
-and thus has no semantic effects and can be stripped at any time.
-Since the producers section is relatively small, tools are encouraged to emit
-the section or include themselves in an existing section by default, keeping
-the producers section even in release builds.
-
-WebAssembly consumers should avoid using the producers section to derive
-optimization hints. To ensure portable performance, hints should be
-standardized in a separate custom section, probably in the core spec's
-[Custom Sections appendix](https://webassembly.github.io/spec/core/appendix/custom.html).
-
-An additional goal of the producers section is to provide a discrete, but
-easily-growable [list of known tools/languages](#known-list) for each
-record field. This avoids the skew that otherwise happens with unstructured
-strings. Unknown names do not invalidate an otherwise-valid producers section.
-However, wasm consumers may provide less accurate telemetry results for unknown
-names or even emit diagnostics encouraging the name to be put on the known list.
-
-Since version information is useful, but highly-variable, each field value
-is accompanied with a version string so that the name can remain stable
-over time without requiring frequent updates to the known list.
+The producers section provides an optional, structured way to record all of the
+distinct tools that were used to produce a given WebAssembly module. The
+producers section is a [custom section](https://webassembly.github.io/spec/core/binary/modules.html#custom-section)
+and thus has no semantic effects. Size-optimizing toolchains are likely to
+strip the producers section from release builds.
 
 ## Custom Section
 
@@ -71,44 +48,3 @@ the field_name's row.
 | `sdk`          | [SDK list](#sdks)    |
 
 [name-ref]: https://webassembly.github.io/spec/core/binary/values.html#names
-
-## Known list
-
-The following lists contain all the known names for the fields listed above.
-**If your tool is not on this list and you'd like it to be, please submit a PR.**
-
-### Source Languages
-
-It is possible for multiple source languages to be present in a single module
-when the output of multiple compiled languages are statically linked together.
-
-* `wat`
-* `C`
-* `C++`
-* `Rust`
-
-### Individual Tools
-
-It is possible (and common) for multiple tools to be used in the overall
-pipeline that produces and optimizes a given wasm module.
-
-* `wabt`
-* `LLVM`
-* `clang`
-* `lld`
-* `Binaryen`
-* `rustc`
-* `wasm-bindgen`
-* `wasm-pack`
-
-### SDKs
-
-While an SDK is technically just another tool, the `sdk` field designates the
-top-level "thing" that the developer installs and interacts with directly to
-produce the wasm module.
-
-* `Emscripten`
-
-## Text format
-
-TODO


### PR DESCRIPTION
As discussed in #93 and the recent [CG meeting](https://github.com/WebAssembly/meetings/blob/master/2019/CG-02-19.md#update-on-producers-section-tool-conventions93-points-to-likely-non-use-in-practice-and-so-next-steps-would-be-to-either-remove-or-soften-wording).