### PR TITLE
Add wasm-snip to known individual tools

### DIFF
--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -101,6 +101,7 @@ pipeline that produces and optimizes a given wasm module.
 * `wasm-bindgen`
 * `wasm-pack`
 * `webassemblyjs`
+* `wasm-snip`
 
 ### SDKs
 


### PR DESCRIPTION
As of version 0.1.5, `wasm-snip` will (optionally) add itself to the "processed-by" individual tools subsection of the "producers" custom section.

https://github.com/rustwasm/wasm-snip/commit/a1332a092811c7e882f9011bef0b515f8ff6c64d