### PR TITLE
Update DynamicLinking.md with current status

### DIFF
--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -1,8 +1,8 @@
 WebAssembly Dynamic Linking
 ===========================
 
-This document describes a proposed ABI for dynamic linking of WebAssembly
-modules along with the current implementation status.
+This document describes the current WebAssembly dynamic linking ABI used by
+emscripten and by the llvm backend when targeting emscripten.
 
 Note: This ABI is still a work in progress.  There is no stable ABI yet.
 

--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -168,6 +168,6 @@ In order to use the llvm output in emscripten (which still uses the old ABI
 described above) a binaryen pass is run as part of `wasm-emscripten-finalize`
 then coverts from the ABI descirbed in this document to the ABI used by the
 emscripten dynamic linker is somewhat different.  The emscripten ABI uses
-specially named functions (e.g. `g$foo` and `fp$foo`) for the accessing the
+specially named functions (e.g. `g$foo` and `fp$foo`) for accessing the
 addresses of the dynamically linked symbols rather than using WebAssembly
 globals.


### PR DESCRIPTION
This change removes the `Planned Changes` section and makes this
the primary ABI.   The old ABI is mentioned only in reference to the
emscripten implementation.