### PR TITLE
Document `NO_STRIP`.

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -274,6 +274,8 @@ The current set of valid flags for symbols are:
   rather than reusing the name from a wasm import. This allows it to remap
   imports from foreign WebAssembly modules into local symbols with different
   names.
+- `0x80 / WASM_SYM_NO_STRIP` - The symbol is intended to be included in the
+  linker output, regardless of whether it is used by the program.
 
 For `WASM_COMDAT_INFO` the following fields are present in the
 subsection:


### PR DESCRIPTION
This adds documentation for the new `NO_STRIP` flag, allowing symbols to
be kept alive to support __attribute__((used)).

The `NO_STRIP` symbol flag is implemented in lld in
https://reviews.llvm.org/D62542 and in LLVM in
https://reviews.llvm.org/D66968.