### PR TITLE
Document __wasm_call_ctors

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -531,7 +531,9 @@ Start Section
 By default the static linker should not output a WebAssembly start
 section. Constructors are instead called from a synthetic function
 `__wasm_call_ctors` that the runtime and embedder should arrange to have called
-after instantiation.
+after instantiation. `__wasm_call_ctors` is not exported by default because it
+may be called by some other startup function defined by the runtime. For the
+embedder to call it directly it should be exported like any other function.
 
 Rationale: Use of the WebAssembly start function was considered for running
 static constructors and/or the main entry point to the program.  However,

--- a/Linking.md
+++ b/Linking.md
@@ -28,6 +28,7 @@ tasks need to be performed:
 - Merging of table sections (re-numbering tables)
 - Merging of data segments (re-positioning data)
 - Resolving undefined external references
+- Synthesizing functions to call constructors and perform other initialization
 
 The linking technique described here is designed to be fast, and avoids having
 to disassemble the code section.  The extra metadata required by the linker
@@ -527,7 +528,10 @@ event symbols in the linked output.)
 Start Section
 -------------
 
-By default the static linker should not output a WebAssembly start section.
+By default the static linker should not output a WebAssembly start
+section. Constructors are instead called from a synthetic function
+`__wasm_call_ctors` that should be exported from the module and called after
+instantiation by the WebAssembly runtime.
 
 Rationale: Use of the WebAssembly start function was considered for running
 static constructors and/or the main entry point to the program.  However,

--- a/Linking.md
+++ b/Linking.md
@@ -530,8 +530,8 @@ Start Section
 
 By default the static linker should not output a WebAssembly start
 section. Constructors are instead called from a synthetic function
-`__wasm_call_ctors` that should be exported from the module and called after
-instantiation by the WebAssembly runtime.
+`__wasm_call_ctors` that the runtime and embedder should arrange to have called
+after instantiation.
 
 Rationale: Use of the WebAssembly start function was considered for running
 static constructors and/or the main entry point to the program.  However,


### PR DESCRIPTION
A user rolling their own toolchain was asking after their missing
constructors on llvm-dev, and I was going to point them to the
documentation of __wasm_call_ctors wehen I discovered that there was
none. This PR fixes that hole in our docs.