### PR TITLE
R_WEBASSEMBLY_* => R_WASM_*

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -115,8 +115,8 @@ A relocation type can be one of the following:
 [varint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#varintn
 [uint32]: https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#uintn
 
-For `R_WASM_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB`,
-`R_WASM_MEMORY_ADDR_I32`, `R_WEBASSEMBLY_FUNCTION_OFFSET_I32`, and
+For `R_WASM_MEMORY_ADDR_LEB`, `R_WASM_MEMORY_ADDR_SLEB`,
+`R_WASM_MEMORY_ADDR_I32`, `R_WASM_FUNCTION_OFFSET_I32`, and
 `R_WASM_SECTION_OFFSET_I32` relocations the following field is additionally
 present:
 
@@ -481,7 +481,7 @@ The final code and data sections are written out with relocations applied.
 shall contain a newly-synthesised type section which contains entries for all
 functions and type relocations in the output.
 
-`R_WASM_TABLE_INDEX_SLEB` and `R_WEBASSEMBLY_TABLE_INDEX_I32` relocations
+`R_WASM_TABLE_INDEX_SLEB` and `R_WASM_TABLE_INDEX_I32` relocations
 cannot fail.  The output Wasm file shall contain a newly-synthesised table,
 which contains an entry for all defined or imported symbols referenced by table
 relocations.  The output table elements shall begin at a non-zero offset within
@@ -503,7 +503,7 @@ in which case there is no legal value that can be written as the target of any
 generate weak globals which may not be defined; a definition or import must
 exist for all global symbols in the linked output.)
 
-`R_WASM_MEMORY_ADDR_LEB`, `R_WEBASSEMBLY_MEMORY_ADDR_SLEB` and
+`R_WASM_MEMORY_ADDR_LEB`, `R_WASM_MEMORY_ADDR_SLEB` and
 `R_WASM_MEMORY_ADDR_I32` relocations cannot fail.  The relocation's value
 is the offset within the linear memory of the symbol within the output segment,
 plus the symbol's addend.  If the symbol is undefined (whether weak or strong),


### PR DESCRIPTION
I think this is just a typo or left over from some old
convention?