### PR TITLE
Update linking docs

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -236,6 +236,8 @@ subsection:
 | count       | `varuint32`  | number of init functions that follow  |
 | functions   | `varuint32*` | sequence of symbol indices            |
 
+The `WASM_INIT_FUNC` subsection must come after the `WASM_SYMBOL_TABLE` subsection.
+
 For `WASM_SYMBOL_TABLE` the following fields are present in the
 subsection:
 

--- a/Linking.md
+++ b/Linking.md
@@ -113,7 +113,7 @@ a 5-byte [varuint32], e.g. the type immediate in a `call_indirect`.
 - `8 / R_WASM_FUNCTION_OFFSET_I32` (since LLVM 10.0) - a byte offset within
 code section for the specific function encoded as a [uint32]. The offsets start
 at the actual function code excluding its size field.
-- `9 / R_WASM_SECTION_OFFSET_I32` (since LLVM 10.0) - an byte offset from start
+- `9 / R_WASM_SECTION_OFFSET_I32` (since LLVM 10.0) - a byte offset from start
 of the specified section encoded as a [uint32].
 - `10 / R_WASM_EVENT_INDEX_LEB` (since LLVM 10.0) - an event index encoded as a
 5-byte [varuint32]. Used for the immediate argument of a `throw` and `if_except`

--- a/Linking.md
+++ b/Linking.md
@@ -106,7 +106,7 @@ instruction, e.g. taking the address of a C++ global.
 - `5 / R_WASM_MEMORY_ADDR_I32` (since LLVM 10.0) - a linear memory index
 encoded  as a [uint32], e.g. taking the address of a C++ global in a static data
 initializer.
-- `6 / R_WASM_TYPE_INDEX_LEB` (since LLVM 10.0) - a type table index encoded as
+- `6 / R_WASM_TYPE_INDEX_LEB` (since LLVM 10.0) - a type index encoded as
 a 5-byte [varuint32], e.g. the type immediate in a `call_indirect`.
 - `7 / R_WASM_GLOBAL_INDEX_LEB` (since LLVM 10.0) - a global index encoded as a
   5-byte [varuint32], e.g. the index immediate in a `get_global`.

--- a/Linking.md
+++ b/Linking.md
@@ -83,7 +83,7 @@ A `relocation_entry` begins with:
 | Field    | Type                | Description                    |
 | -------- | ------------------- | ------------------------------ |
 | type     | `uint8`             | the relocation type            |
-| offset   | `varuint32`         | offset of the value to rewrite (relative to the relevant section's body: offset zero is immediately after the id and size of the section) |
+| offset   | `varuint32`         | offset of the value to rewrite (relative to the relevant section's contents: offset zero is immediately after the id and size of the section) |
 | index    | `varuint32`         | the index of the symbol used (or, for `R_WASM_TYPE_INDEX_LEB` relocations, the index of the type) |
 
 A relocation type can be one of the following:
@@ -169,7 +169,7 @@ Note that for all relocation types, the bytes being relocated:
 * or from `offset` to `offset + 8` for I64;
 
 must lie within the section to which the relocation applies (as offsets are relative
-to the section's body, this means that they cannot be too large). In addition,
+to the section's contents, this means that they cannot be too large). In addition,
 the bytes being relocated may not overlap the boundary between the section's chunks,
 where such a distinction exists (it may not for custom sections).  For example, for
 relocations applied to the CODE section, a relocation cannot straddle two
@@ -373,7 +373,7 @@ The target features section is an optional custom section with the name
 "target_features". The target features section must come after the
 ["producers"](#linking-metadata-section) section.
 
-The body of the target features section is a vector of entries:
+The contents of the target features section is a vector of entries:
 
 | Field   | Type    | Description                              |
 | ------- | ------- | ---------------------------------------- |

--- a/Linking.md
+++ b/Linking.md
@@ -59,7 +59,7 @@ section.
 
 Relocation sections can only target code, data and custom sections.
 All other sections are synthetic sections: that is, rather than being
-`memcpy`'d into place as the code code and data sections are, they
+`memcpy`'d into place as the code and data sections are, they
 are created from scratch by the linker.
 
 The "reloc." custom sections must come after the

--- a/Linking.md
+++ b/Linking.md
@@ -57,6 +57,11 @@ A relocation section is a user-defined section with a name starting with
 section they apply to, and must be sequenced in the module after that
 section.
 
+Relocation sections can only target code, data and custom sections.
+All other sections are synthetic sections: that is, rather than being
+`memcpy`'d into place as the code code and data sections are, they
+are created from scratch by the linker.
+
 The "reloc." custom sections must come after the
 ["linking"](#linking-metadata-section) custom section in order to validate
 relocation indices.

--- a/Linking.md
+++ b/Linking.md
@@ -196,7 +196,7 @@ section:
 | subsections | `subsection*` | sequence of `subsection`             |
 
 This `version` allows for breaking changes to be made to the format described
-here.  Tools can then choose to reject imputs contained unexpected versions.
+here.  Tools can then choose to reject inputs containing unexpected versions.
 
 Each `subsection` is encoded as:
 

--- a/Linking.md
+++ b/Linking.md
@@ -239,7 +239,14 @@ subsection:
 | Field       | Type         | Description                           |
 | ----------- | ------------ | ------------------------------------- |
 | count       | `varuint32`  | number of init functions that follow  |
-| functions   | `varuint32*` | sequence of symbol indices            |
+| functions   | `init_func*` | sequence of `init_func`               |
+
+where an `init_func` is encoded as:
+
+| Field        | Type        | Description                                                  |
+| ------------ | ----------- | ------------------------------------------------------------ |
+| priority     | `varuint32` | priority of the init function                                |
+| symbol_index | `varuint32` | the symbol index of init function (*not* the function index) |
 
 The `WASM_INIT_FUNC` subsection must come after the `WASM_SYMBOL_TABLE` subsection.
 

--- a/Linking.md
+++ b/Linking.md
@@ -3,9 +3,9 @@ WebAssembly Object File Linking
 
 This document describes the WebAssembly object file format and the ABI used for
 statically linking them to produce an executable WebAssembly module. This is
-currently implemented in the clang/LLVM WebAssembly 
-backend and other tools such as binaryen and wabt.  As mentioned in 
-[README](README.md), this is not part of the official WebAssembly specification 
+currently implemented in the clang/LLVM WebAssembly
+backend and other tools such as binaryen and wabt.  As mentioned in
+[README](README.md), this is not part of the official WebAssembly specification
 and other runtimes may choose to follow a different set of linking conventions.
 
 Overview
@@ -57,18 +57,18 @@ A relocation section is a user-defined section with a name starting with
 section they apply to, and must be sequenced in the module after that
 section.
 
-Relocation sections can only target code, data and custom sections.
-All other sections are synthetic sections: that is, rather than being
-`memcpy`'d into place as the code and data sections are, they
-are created from scratch by the linker.
+Relocation sections can only target code, data and custom sections. All other
+sections are synthetic sections: that is, rather than being `memcpy`'d into
+place as the code and data sections are, they are created from scratch by the
+linker.
 
 The "reloc." custom sections must come after the
 ["linking"](#linking-metadata-section) custom section in order to validate
 relocation indices.
 
-Any LEB128-encoded values should be maximally padded so that they can be rewritten
-without affecting the position of any other bytes. For instance, the function index
-3 should be encoded as `0x83 0x80 0x80 0x80 0x00`.
+Any LEB128-encoded values should be maximally padded so that they can be
+rewritten without affecting the position of any other bytes. For instance, the
+function index 3 should be encoded as `0x83 0x80 0x80 0x80 0x00`.
 
 Relocations contain the following fields:
 

--- a/Linking.md
+++ b/Linking.md
@@ -66,6 +66,10 @@ The "reloc." custom sections must come after the
 ["linking"](#linking-metadata-section) custom section in order to validate
 relocation indices.
 
+Any LEB128-encoded values should be maximally padded so that they can be rewritten
+without affecting the position of any other bytes. For instance, the function index
+3 should be encoded as `0x83 0x80 0x80 0x80 0x00`.
+
 Relocations contain the following fields:
 
 | Field     | Type                | Description                     |

--- a/Linking.md
+++ b/Linking.md
@@ -83,7 +83,7 @@ A `relocation_entry` begins with:
 | Field    | Type                | Description                    |
 | -------- | ------------------- | ------------------------------ |
 | type     | `uint8`             | the relocation type            |
-| offset   | `varuint32`         | offset of the value to rewrite (relative to the relevant section's body) |
+| offset   | `varuint32`         | offset of the value to rewrite (relative to the relevant section's body: offset zero is immediately after the id and size of the section) |
 | index    | `varuint32`         | the index of the symbol used (or, for `R_WASM_TYPE_INDEX_LEB` relocations, the index of the type) |
 
 A relocation type can be one of the following:


### PR DESCRIPTION
I've just finished updating a toy compiler to output object files instead of using the text format, so I thought it'd be good to include things that weren't clear to me from reading through the linking docs.

There are some details that I think would still be useful to include somewhere, although I'm not sure what the most appropriate place would be, nor am I sure whether there are alternative methods for the below. My impression, mostly from writing some C code and inspecting the resulting object file, is:

* rather than defining memory in the object file, memory should be imported from `env.__linear_memory`
* rather than defining a function table, one should be imported from `env.__indirect_function_table`
* on recent (>= 12) versions of LLVM, if `__wasm_call_ctors` is not called, then each exported function is wrapped in a function that first calls `__wasm_call_ctors` before calling the original function

I should also add that the fact that I was able to get things working within roughly a weekend, despite not being well versed in this sort of stuff, is a positive sign to some combination of an understandable design and good docs. So, thanks for putting this together in the first place!