### PR TITLE
Remove obsolete paragraph about dynamic linking

### DIFF
--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -227,11 +227,3 @@ See `test_dylink_*` and `test_dlfcn_*` in the test suite for examples.
 
 Emscripten can create WebAssembly dynamic libraries with its `SIDE_MODULE`
 option, see [the wiki](https://github.com/kripken/emscripten/wiki/WebAssembly-Standalone).
-
-In order to use the llvm output in emscripten (which still uses the old ABI
-described above) a binaryen pass is run as part of `wasm-emscripten-finalize`
-then coverts from the ABI described in this document to the ABI used by the
-emscripten dynamic linker is somewhat different.  The emscripten ABI uses
-specially named functions (e.g. `g$foo` and `fp$foo`) for accessing the
-addresses of the dynamically linked symbols rather than using WebAssembly
-globals.


### PR DESCRIPTION
Emscripten no longer has to rewrite LLVM's output for dynamic libraries.