### PR TITLE
Fix CodeMetadata encoding definition for trace_inst

### DIFF
--- a/CodeMetadata.md
+++ b/CodeMetadata.md
@@ -99,7 +99,7 @@ Code transformations that remove the instruction should remove the associated in
 
 ```
 codemetadatainstance(trace_inst) ::= funcpos: u32
-               size: 0x04
+               size: u32v
                data: mark_id
 mark_id ::= u32
 ```


### PR DESCRIPTION
Change size from a fixed value of 0x4 to a variable unsigned integer.