### PR TITLE
Linking: Add the missing list of segment flags

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -232,7 +232,7 @@ where a `segment` is encoded as:
 
 The current set of valid flag for segments are:
 - `1 / WASM_SEGMENT_FLAG_STRINGS` - Signals that the segment contains only null terminated strings allowing the linker to perform merging.
-- `2 / WASM_SEGMENT_FLAG_TLS` - The segment contains thread-local data. This means it a unique copy of this segment will be created for each thread.
+- `2 / WASM_SEGMENT_FLAG_TLS` - The segment contains thread-local data. This means that a unique copy of this segment will be created for each thread.
 
 For `WASM_INIT_FUNCS` the following fields are present in the
 subsection:

--- a/Linking.md
+++ b/Linking.md
@@ -230,6 +230,10 @@ where a `segment` is encoded as:
 | alignment    | `varuint32`  | The required alignment of the segment, encoded as a power of 2 |
 | flags        | `varuint32`  | a bitfield containing flags for this segment  |
 
+The current set of valid flag for segments are:
+- `1 / WASM_SEGMENT_FLAG_STRINGS`
+- `2 / WASM_SEGMENT_FLAG_TLS`
+
 For `WASM_INIT_FUNCS` the following fields are present in the
 subsection:
 

--- a/Linking.md
+++ b/Linking.md
@@ -231,8 +231,8 @@ where a `segment` is encoded as:
 | flags        | `varuint32`  | a bitfield containing flags for this segment  |
 
 The current set of valid flag for segments are:
-- `1 / WASM_SEGMENT_FLAG_STRINGS`
-- `2 / WASM_SEGMENT_FLAG_TLS`
+- `1 / WASM_SEGMENT_FLAG_STRINGS` - Signals that the segment contains only null terminated strings allowing the linker to perform merging.
+- `2 / WASM_SEGMENT_FLAG_TLS` - The segment contains thread-local data. This means it a unique copy of this segment will be created for each thread.
 
 For `WASM_INIT_FUNCS` the following fields are present in the
 subsection:


### PR DESCRIPTION
## Problem

The documentation for the `WASM_SEGMENT_INFO` subsection includes a `flags` field, but I didn't see any mention of the flags themselves, yet I found a STRINGS flags being encoded and decoded in practice by both clang and wasm-objdump.

It looks like these are the definitions of these in the header files [wabt/common.h](https://github.com/WebAssembly/wabt/blob/e97a1cbe920b96174c59ee347969eaf42d4116f0/include/wabt/common.h#L334-L335) and [llvm/BinaryFormat/Wasm.h](https://github.com/llvm/llvm-project/blob/142e567cf00815f7d1b3d72aaf298212a3f83ab2/llvm/include/llvm/BinaryFormat/Wasm.h#L392-L395)

## Solution

I have just listed these flag names along with their values for now, since I didn't want to lead the reader astray by making assumptions about how these flags are used during linking.  Feel free to add descriptions if you have more confidence about their purpose, otherwise, I will try to get around adding these later.