### PR TITLE
Add a text format for `producers` and `dylink.0` custom sections

### DIFF
--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -234,15 +234,15 @@ extension to the WebAssembly text format. The text format looks like:
 )
 ```
 
-The `(@dylink.0 ...)` structure must be placed directly within an `(@module
+The `(@dylink.0 ...)` structure must be placed directly within a `(module
 ...)` declaration and must be placed at the beginning of the module. Within
-`@dylink.0` there is a list of parenthesis-delimited fields. The four accepted
-fields correspond to the subsections within `dylink.0`:
+`@dylink.0` there is a list of four possible parenthesis-delimited fields that
+correspond to the subsections within `dylink.0`:
 
-* `(@mem-info ...)`
-* `(@needed ...)`
-* `(@export-info ...)`
-* `(@import-info ...)`
+* `(mem-info ...)`
+* `(needed ...)`
+* `(export-info ...)`
+* `(import-info ...)`
 
 The `dylink.0` subsections are emitted in the same order they're listed within
 the `@dylink.0` annotation. The `export-info` and `import-info` subsections

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -130,14 +130,14 @@ extension to the WebAssembly text format. The text format looks like:
 )
 ```
 
-The `(@producers ...)` structure must be placed directly within an `(@module
+The `(@producers ...)` structure must be placed directly within a `(module
 ...)` declaration. Within `@producers` there is a list of parenthesis-delimited
 fields. The three accepted fields correspond to the three possible `field_name`s
 above:
 
-* `(@language ...)`
-* `(@processed-by ...)`
-* `(@sdk ...)`
+* `(language ...)`
+* `(processed-by ...)`
+* `(sdk ...)`
 
 Each field takes two strings corresponding to the `name` and `version` fields of
 the `versioned-name` construction in the custom section. For example:

--- a/ProducersSection.md
+++ b/ProducersSection.md
@@ -116,4 +116,53 @@ produce the wasm module.
 
 ## Text format
 
-TODO
+The text format for the `producers` custom section uses [annotations proposal]
+extension to the WebAssembly text format. The text format looks like:
+
+[annotations proposal]: https://github.com/WebAssembly/annotations
+
+```wasm
+(module
+  (@producers
+    (processed-by "rustc" "1.78.0 (9b00956e5 2024-04-29)")
+    (language "Rust" "1.78.0")
+  )
+)
+```
+
+The `(@producers ...)` structure must be placed directly within an `(@module
+...)` declaration. Within `@producers` there is a list of parenthesis-delimited
+fields. The three accepted fields correspond to the three possible `field_name`s
+above:
+
+* `(@language ...)`
+* `(@processed-by ...)`
+* `(@sdk ...)`
+
+Each field takes two strings corresponding to the `name` and `version` fields of
+the `versioned-name` construction in the custom section. For example:
+
+```wasm
+(module
+  (@producers
+    (language "C" "18.1.2")
+    (processed-by "LLVM" "18.1.2")
+    (sdk "Emscripten" "3.1.60")
+  )
+)
+```
+
+The three fields can be specified in any order and any number of times.
+
+```wasm
+(module
+  (@producers
+    (sdk "Emscripten" "3.1.60")
+    (processed-by "LLVM" "18.1.2")
+    (language "C" "18.1.2")
+    (processed-by "LLVM" "17.1.0")
+    (language "Rust" "1.78.0")
+    (processed-by "clang" "18.1.2")
+  )
+)
+```


### PR DESCRIPTION
This proposes a text format based on the annotations proposal for two custom sections defined in this repository. The annotations proposal is likely to reach phase 4 and "basically done" status in the near future. The [wasm-tools repository][tools] has implemented the text format documented here for a bit now and it seemed best to document this upstream as well to both gather consensus and help guide other implementations.

[tools]: https://github.com/bytecodealliance/wasm-tools

I'll note that the text format documented here is the first thing I thought of for these sections. Right now these are largely used in read-only capacities where it's helpful for inspecting output but I'm not aware of anyone relying on the exact syntax. In that sense I'm more than happy to change syntax here and bikeshed a bit, I don't want to just assume that what's proposed here can't change.