### PR TITLE
[Linking] Remove 'Required' (0x3d) prefix from features section

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -402,15 +402,14 @@ The contents of the target features section is a vector of entries:
 
 The recognized prefix bytes and their meanings are below. When the user does not
 supply a set of allowed features explicitly, the set of allowed features is
-taken to be the set of features used or required. Any feature not mentioned in
-an object's target features section is not used by that object, but is not
-necessarily prohibited in the final binary.
+taken to be the set of features used. Any feature not mentioned in an object's
+target features section is not used by that object, but is not necessarily
+prohibited in the final binary.
 
 | Prefix     | Meaning |
 | ---------- | ------- |
 | 0x2b (`+`) | This object uses this feature, and the link fails if this feature is not in the allowed set. |
 | 0x2d (`-`) | This object does not use this feature, and the link fails if this feature is in the allowed set. |
-| 0x3d (`=`) | This object uses this feature, and the link fails if this feature is not in the allowed set or if any object does not use this feature. |
 
 The generally accepted features are:
 

--- a/Linking.md
+++ b/Linking.md
@@ -402,7 +402,7 @@ The contents of the target features section is a vector of entries:
 
 The recognized prefix bytes and their meanings are below. When the user does not
 supply a set of allowed features explicitly, the set of allowed features is
-taken to be the set of features used. Any feature not mentioned in an object's
+taken to be the set of used features. Any feature not mentioned in an object's
 target features section is not used by that object, but is not necessarily
 prohibited in the final binary.
 


### PR DESCRIPTION
This has not been emitted in LLVM since
https://github.com/llvm/llvm-project/commit/3f34e1b883351c7d98426b084386a7aa762aa366.