### PR TITLE
Fix CodeMetadata.md example annotations

### DIFF
--- a/CodeMetadata.md
+++ b/CodeMetadata.md
@@ -60,8 +60,8 @@ Example:
 ```
 (module
   (type (;0;) (func (param i32 result i32)))
-  (func (@metadata.code.hotness "\1") $test (type 0)
-    (@metadata.code.branch_hint "\0") if
+  (func (@metadata.code.hotness "\01") $test (type 0)
+    (@metadata.code.branch_hint "\00") if
       i32.const 0
       local.set 0
     end


### PR DESCRIPTION
"\0" and "\1" there are meant to indicate bytes, but two characters are needed for that text encoding (for a whole byte).

This makes the example match the BranchHinting example:

https://github.com/WebAssembly/branch-hinting/blob/main/proposals/branch-hinting/Overview.md

and also makes them parse properly in the spec interpreter and Binaryen.