### PR TITLE
Add text format specification for Linking.md

### DIFF
--- a/Linking.md
+++ b/Linking.md
@@ -856,6 +856,15 @@ like following:
 
 ## Symbols
 
+For each relocatable WebAssembly entity type, there exists a corresponding
+symbol identifier namespaces for symbols of that type.
+
+Additionally, a symbol identifier namespace exists for data symbols.
+
+Symbol idenitfier namespaces differ from common index spaces in that they also
+allow purely textual names in addition to numeric + optional textual names
+allowed by index spaces.
+
 Symbols are represented as WebAssembly annotations of the form
 ```wat
 (@sym <name> <qualifier>*)
@@ -870,8 +879,16 @@ Data imports represented as WebAssembly annotations of the form
   symbol is considered *primary* symbol for that WebAssembly object, its name
   is taken from the related object
   - There may only be one primary symbol for each WebAssembly object.
-  - If a symbol is not associated with an object, it may not be the primary
-    symbol.
+  - If a symbol is not associated with a WebAssembly entity, it may not be the
+    primary symbol.
+
+After a name for the symbol is determined, it is placed into the symbol
+identifier namespace corresponding to that symbol type.
+
+> [!Note]
+> As a consequence of that, the only symbols that can be referred to by a
+> numeric index are _primary_ symbols, since they inherit their numeric index
+> form the relocatable WebAssebly object.
 
 - `qualifier` is one of the allowed qualifiers on a symbol declaration.
   Qualifiers may not repeat.
@@ -914,6 +931,11 @@ Shorthands may be used in place of full qualifiers:
 
 If all components of a symbol annotation are skipped, the annotation may be
 omitted.
+
+> [!Note]
+> Since all components of a symbol can be skipped, a _primary_ symbol always
+> exists for all WebAssembly entities, even if the annotation without a `name`
+> is not present in the symbol sequence
 
 ### WebAssembly object symbols
 

--- a/Linking.md
+++ b/Linking.md
@@ -769,6 +769,7 @@ Relocations are represented as WebAssembly annotations of the form
 | `datasec`   | data        | `R_WASM_SECTION_OFFSET`            | Offset into a data section        |
 | `customsec` | N/A         | `R_WASM_SECTION_OFFSET`            | Offset into a custom section      |
 | `data`      | data        | `R_WASM_MEMORY_ADDR_*`             | WebAssembly linear memory address |
+
 Symbol kinds marked with `*` are considered *primary*.
 
 - `modifier` describes the additional attributes that a relocation might have.

--- a/Linking.md
+++ b/Linking.md
@@ -764,9 +764,9 @@ Relocations are represented as WebAssembly annotations of the form
 | `global`    | global*     | `R_WASM_GLOBAL_INDEX_*`            | Final WebAssembly global index    |
 | `func`      | function*   | `R_WASM_FUNCTION_INDEX_*`          | Final WebAssembly function index  |
 | `functable` | function    | `R_WASM_TABLE_INDEX_*`             | Index into the dynamic function table, used for taking address of functions |
-| `text`      | function    | `R_WASM_FUNCTION_OFFSET`           | Offset into the function body     |
-| `funcsec`   | function    | `R_WASM_SECTION_OFFSET`            | Offset into a function section    |
-| `datasec`   | data        | `R_WASM_SECTION_OFFSET`            | Offset into a data section        |
+| `codeseg`   | function    | `R_WASM_FUNCTION_OFFSET`           | Offset into the function body from the start of the function |
+| `codesec`   | function    | `R_WASM_SECTION_OFFSET`            | Offset into the function section  |
+| `datasec`   | data        | `R_WASM_SECTION_OFFSET`            | Offset into the data section      |
 | `customsec` | N/A         | `R_WASM_SECTION_OFFSET`            | Offset into a custom section      |
 | `data`      | data        | `R_WASM_MEMORY_ADDR_*`             | WebAssembly linear memory address |
 
@@ -782,12 +782,12 @@ Symbol kinds marked with `*` are considered *primary*.
 
 - `addend` describes the additional components of a relocation.
 
-| `<addend>`   | interpretation       | condition                                                         |
-|--------------|----------------------|-------------------------------------------------------------------|
-| nothing      | Zero addend          | always                                                            |
-| `+<integer>` | Positive byte offset | `method` allows addend                                            |
-| `-<integer>` | Negative byte offset | `method` allows addend and `format` is signed                     |
-| `<labeluse>` | Byte offest to label | `method` allows addend and `method` is either `text` or `section` |
+| `<addend>`   | interpretation       | condition                                     |
+|--------------|----------------------|-----------------------------------------------|
+| nothing      | Zero addend          | always                                        |
+| `+<integer>` | Positive byte offset | `method` allows addend                        |
+| `-<integer>` | Negative byte offset | `method` allows addend and `format` is signed |
+| `<labeluse>` | Byte offest to label | `method` is either `codeseg` or `*sec`        |
 
 - `symbol` describes the symbol against which to perform relocation.
   - For `funcsec` relocation method, this is the function id, so that if the addend is zero, the relocation points to the first instruction of that function.

--- a/Linking.md
+++ b/Linking.md
@@ -899,7 +899,7 @@ identifier namespace corresponding to that symbol type.
 | `binding=<binding>`       | sets symbol flags according to `<binding>`    |
 | `visibility=<visibility>` | sets symbol flags according to `<visibility>` |
 | `retain`                  | sets `WASM_SYM_NO_STRIP` symbol flag          |
-| `thread_local`            | sets `WASM_SYM_TLS` symbol flag               |
+| `tls`                     | sets `WASM_SYM_TLS` symbol flag               |
 | `size=<int>`              | sets symbol's `size` appropriately            |
 | `offset=<int>`            | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately |
 | `name=<string>`           | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets symbol's `name_len`, `name_data` appropriately |

--- a/Linking.md
+++ b/Linking.md
@@ -843,10 +843,11 @@ In data segments, relocation annotations can be interleaved into the data
 string sequence. When that happens, relocations are situated after the last
 byte of the value being relocated.
 
-For example, relocation of a 32-bit function pointer `$foo` into the data
-segment of size 4 would look like following:
+For example, relocation of a 32-bit function pointer `$foo` and a 32-bit
+reference to a data symbol `$bar` into the data segment of size 8 would look
+like following:
 ```wat
-(data (i32.const 0) "\00\00\00\00" (@reloc i32 functbl $foo))
+(data (i32.const 0) "\00\00\00\00" (@reloc i32 functbl $foo) "\00\00\00\00" (@reloc i32 data $bar))
 ```
 
 ## Symbols

--- a/Linking.md
+++ b/Linking.md
@@ -752,8 +752,8 @@ Relocations are represented as WebAssembly annotations of the form
 |`i64`     | `R_WASM_*_I64`                     | 8-byte [uint64]     |
 |`leb`     | `R_WASM_*_LEB`                     | 5-byte [varuint32]  |
 |`sleb`    | `R_WASM_*_SLEB`                    | 5-byte [varint32]   |
-|`leb64`   | `R_WASM_*_LEB`                     | 10-byte [varuint64] |
-|`sleb64`  | `R_WASM_*_SLEB`                    | 10-byte [varint64]  |
+|`leb64`   | `R_WASM_*_LEB64`                   | 10-byte [varuint64] |
+|`sleb64`  | `R_WASM_*_SLEB64`                  | 10-byte [varint64]  |
 
 - `method` describes the type of relocation, so what kind of symbol we are relocating against and how to interpret that symbol.
 
@@ -790,10 +790,10 @@ Symbol kinds marked with `*` are considered *primary*.
 | `<labeluse>` | Byte offest to label | `method` allows addend and `method` is either `text` or `section` |
 
 - `symbol` describes the symbol against which to perform relocation.
-  - For `funcsec` relocation metod, this is the function id, so that if the addend is zero, the relocation points to the first instruction of that function.
-  - For `datasec` relocation metod, this is the data segment id, so that if the addend is zero, the relocation points to the first byte of data in that segment.
-  - For `customsec` relocation metod, this is the name of the custom section, so that if the addend is zero, the relocation points to the first byte of data in that segment.
-  - For other relocation metods, this denotes the symbol in the scope of that symbol kind.
+  - For `funcsec` relocation method, this is the function id, so that if the addend is zero, the relocation points to the first instruction of that function.
+  - For `datasec` relocation method, this is the data segment id, so that if the addend is zero, the relocation points to the first byte of data in that segment.
+  - For `customsec` relocation method, this is the name of the custom section, so that if the addend is zero, the relocation points to the first byte of data in that segment.
+  - For other relocation methods, this denotes the symbol in the scope of that symbol kind.
 
 The relocation type is looked up from the combination of `format`, `method`, and `modifier`. If no relocation type exists, an error is raised.
 
@@ -807,11 +807,11 @@ If all components of a relocation annotation are skipped, the annotation may be 
 
 ### Instruction relocations
 
-For every usage of an `typeidx`, `funcidx`, `globalidx`, `tagidx`, a relocation annotation is added afterwards, with `format` predefined as `leb`, `method` predefined as the *primary* method for that type, and `symbol` defaulted as the *primary* symbol of that `idx`
+For every usage of `typeidx`, `funcidx`, `globalidx`, `tagidx`, a relocation annotation is added afterwards, with `format` predefined as `leb`, `method` predefined as the *primary* method for that type, and `symbol` defaulted as the *primary* symbol of that `idx`
 
-For the `i32.const` instruction, a relocation annotation is added after the integer literal operand, with `format` predefined as `sleb`, and `method` is allowed to be either `data` or `functable`.
-For the `i64.const` instruction, a relocation annotation is added after the integer literal operand, with `format` predefined as `sleb64`, and `method` is allowed to be either `data` or `functable`.
-For the `i{32,64}.{load,store}*` instructions, a relocation annotation is added after the offset operand, with `format` predefined as `leb` if the *memory* being referenced is 32-bit, and `leb64` otherwise, and `method` predefined as `data`.
+- For the `i32.const` instruction, a relocation annotation is added after the integer literal operand, with `format` predefined as `sleb`, and `method` is allowed to be either `data` or `functable`.
+- For the `i64.const` instruction, a relocation annotation is added after the integer literal operand, with `format` predefined as `sleb64`, and `method` is allowed to be either `data` or `functable`.
+- For the `i{32,64}.{load,store}*` instructions, a relocation annotation is added after the offset operand, with `format` predefined as `leb` if the *memory* being referenced is 32-bit, and `leb64` otherwise, and `method` predefined as `data`.
 
 ### Data relocations
 
@@ -838,29 +838,29 @@ Data imports represented as WebAssembly annotations of the form
 
 - `qualifier` is one of the allowed qualifiers on a symbol declaration. Qualifiers may not repeat.
 
-| `<qualifier>`    | effect                                                                           |
-|------------------|----------------------------------------------------------------------------------|
-| `weak`           | sets `WASM_SYM_BINDING_WEAK` symbol flag                                         |
-| `static`         | sets `WASM_SYM_BINDING_LOCAL` symbol flag                                        |
-| `hidden`         | sets `WASM_SYM_VISIBILITY_HIDDEN` symbol flag                                    |
-| `retain`         | sets `WASM_SYM_NO_STRIP` symbol flag                                             |
-| `thread_local`   | sets `WASM_SYM_TLS` symbol flag                                                  |
-| `size=<int>`     | sets symbol's `size` appropriately                                               |
-| `offset=<int>`   | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately       |
-| `name=<string>`  | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets `name_len`, `name_data`          |
-| `priority=<int>` | adds symbol to `WASM_INIT_FUNCS` section with the given priority                 |
-| `comdat=<id>`    | adds symbol to a `comdat` with the given id                                      |
+| `<qualifier>`    | effect                                                                                         |
+|------------------|------------------------------------------------------------------------------------------------|
+| `weak`           | sets `WASM_SYM_BINDING_WEAK` symbol flag                                                       |
+| `static`         | sets `WASM_SYM_BINDING_LOCAL` symbol flag                                                      |
+| `hidden`         | sets `WASM_SYM_VISIBILITY_HIDDEN` symbol flag                                                  |
+| `retain`         | sets `WASM_SYM_NO_STRIP` symbol flag                                                           |
+| `thread_local`   | sets `WASM_SYM_TLS` symbol flag                                                                |
+| `size=<int>`     | sets symbol's `size` appropriately                                                             |
+| `offset=<int>`   | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately                     |
+| `name=<string>`  | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets symbol's `name_len`, `name_data` appropriately |
+| `priority=<int>` | adds symbol to `WASM_INIT_FUNCS` section with the given priority                               |
+| `comdat=<id>`    | adds symbol to a `comdat` with the given id                                                    |
 
-`priority` qualifier may only be applied to function symbols.
-`size` and `offset` qualifiers may only be applied to data symbols.
-`size` and `name` qualifiers must be applied to data symbols.
-`name` qualifier must be applied to data imports.
+- The `priority` qualifier may only be applied to function symbols.
+- The `size` and `offset` qualifiers may only be applied to data symbols.
+- The `size` and `name` qualifiers must be applied to data symbols.
+- The `name` qualifier must be applied to data imports.
 
 If all components of a symbol annotation are skipped, the annotation may be omitted.
 
 ### WebAssembly object symbols
 
-For symbols related to WebAssembly objects, the sequence of symbol annotation occurs after the optional `id` of the declaration.
+For symbols related to WebAssembly objects, the symbol annotation sequence occurs after the optional `id` of the declaration.
 For example, the following code:
 ```wat
 (import "env" "foo" (func (@sym $a retain name="a") (@sym $b hidden name="b") (param) (result)))
@@ -870,7 +870,7 @@ declares 3 symbols: one primary symbol with the name of the index of the functio
 ### Data symbols
 
 Data symbol annotations can be interleaved into the data string sequence. When that happens, relocations are situated before the first byte of the value being defined.
-For example, declaration of a 32-bit global by with the name `$foo` and linkage name "foo" would look like following:
+For example, a declaration of a 32-bit global with the name `$foo` and linkage name "foo" would look like following:
 ```wat
 (data (i32.const 0) (@sym $foo name="foo" size=4) "\00\00\00\00")
 ```
@@ -891,22 +891,28 @@ COMDAT declarations occur in the same place as module fields.
 
 ## Labels
 
-For some relocation types, an offset into a section/function is necessary. For these cases, lablels exsist.
+For some relocation types, an offset into a section/function is necessary. For these cases, labels exsist.
 Labels are represented as WebAssembly annotations of the form
 ```wat
 (@sym.label <id>)
 ```
 
 ### Function labels
-Function labels occur in the same place as instructions. A label always denotes the first byte of the next instruction, or the byte after end of function's instruction stream if there isn't a next instruction
+Function labels occur in the same place as instructions.
+A label always denotes the first byte of the next instruction, or the byte after the end of the function's instruction stream, if there isn't a next instruction.
+
 Function label names are local to the function in which they occur.
 
 ### Data labels
-Data labels can be interleaved into the data string sequence. When that happens, relocations are situated after the last byte of the value being relocated.
+Data labels can be interleaved into the data string sequence.
+When that happens, relocations are situated after the last byte of the value being relocated.
+
 Data label names are local to the data segment in which they occur.
 
 ### Custom labels
-Custom labels can be interleaved into the data string sequence. When that happens, relocations are situated after the last byte of the value being relocated.
+Custom labels can be interleaved into the data string sequence.
+When that happens, relocations are situated after the last byte of the value being relocated.
+
 Custom label names are local to the custom section in which they occur.
 
 ## Data segment flags
@@ -917,13 +923,13 @@ Data segment flags are represented as WebAssembly annotations of the form
 
 - `qualifier` is one of the allowed qualifiers on a data segment declaration. Qualifiers may not repeat.
 
-| `<qualifier>`   | effect                                        |
-|-----------------|-----------------------------------------------|
-| `align=<int>`   | sets segment's `alignment` appropriately      |
-| `name=<string>` | sets `name_len`, `name_data`                  |
-| `strings`       | sets `WASM_SEGMENT_FLAG_STRINGS` segment flag |
-| `thread_local`  | sets `WASM_SEGMENT_FLAG_TLS` segment flag     |
-| `retain`        | sets `WASM_SEG_FLAG_RETAIN` segment flag      |
+| `<qualifier>`   | effect                                               |
+|-----------------|------------------------------------------------------|
+| `align=<int>`   | sets segment's `alignment` appropriately             |
+| `name=<string>` | sets segment's `name_len`, `name_data` appropriately |
+| `strings`       | sets `WASM_SEGMENT_FLAG_STRINGS` segment flag        |
+| `thread_local`  | sets `WASM_SEGMENT_FLAG_TLS` segment flag            |
+| `retain`        | sets `WASM_SEG_FLAG_RETAIN` segment flag             |
 
 If `align` is not specified, it is given a default value of 1.
 If `name` is not specified, it is given an empty default value.

--- a/Linking.md
+++ b/Linking.md
@@ -290,11 +290,12 @@ where a `syminfo` is encoded as:
 |              |                |   `5 / SYMTAB_TABLE`                        |
 | flags        | `varuint32`    | a bitfield containing flags for this symbol |
 
-For functions, globals, events and tables, we reference an existing Wasm object, which
-is either an import or a defined function/global/event/table (recall that the operand of a
-Wasm `call` instruction uses an index space consisting of the function imports
-followed by the defined functions, and similarly `get_global` for global imports
-and definitions and `throw` for event imports and definitions).
+For functions, globals, events and tables, we reference an existing WebAssembly
+entity, which is either an import or a defined function/global/event/table
+(recall that the operand of a Wasm `call` instruction uses an index space
+consisting of the function imports followed by the defined functions, and
+similarly `get_global` for global imports and definitions and `throw` for event
+imports and definitions).
 
 If a symbols refers to an import, and the
 `WASM_SYM_EXPLICIT_NAME` flag is not set, then the name is taken from the
@@ -302,7 +303,7 @@ import; otherwise the `syminfo` specifies the symbol's name.
 
 | Field        | Type           | Description                                 |
 | ------------ | -------------- | ------------------------------------------- |
-| index        | `varuint32`    | the index of the Wasm object corresponding to the symbol, which references an import if and only if the `WASM_SYM_UNDEFINED` flag is set  |
+| index        | `varuint32`    | the index of the WebAssembly entity corresponding to the symbol, which references an import if and only if the `WASM_SYM_UNDEFINED` flag is set  |
 | name_len     | `varuint32` ?  | the optional length of `name_data` in bytes, omitted if `index` references an import |
 | name_data    | `bytes` ?      | UTF-8 encoding of the symbol name, omitted if `index` references an import |
 
@@ -876,9 +877,9 @@ Data imports represented as WebAssembly annotations of the form
 
 - `name` is the symbol name written as WebAssembly `id`, it is the name by
   which relocation annotations reference the symbol. If it is not present, the
-  symbol is considered *primary* symbol for that WebAssembly object, its name
-  is taken from the related object
-  - There may only be one primary symbol for each WebAssembly object.
+  symbol is considered *primary* symbol for that WebAssembly entity, its name
+  is taken from the related entity
+  - There may only be one primary symbol for each WebAssembly entity.
   - If a symbol is not associated with a WebAssembly entity, it may not be the
     primary symbol.
 
@@ -888,7 +889,7 @@ identifier namespace corresponding to that symbol type.
 > [!Note]
 > As a consequence of that, the only symbols that can be referred to by a
 > numeric index are _primary_ symbols, since they inherit their numeric index
-> form the relocatable WebAssebly object.
+> form the relocatable WebAssebly entity.
 
 - `qualifier` is one of the allowed qualifiers on a symbol declaration.
   Qualifiers may not repeat.
@@ -937,9 +938,9 @@ omitted.
 > exists for all WebAssembly entities, even if the annotation without a `name`
 > is not present in the symbol sequence
 
-### WebAssembly object symbols
+### WebAssembly entity symbols
 
-For symbols related to WebAssembly objects, the symbol annotation sequence
+For symbols related to WebAssembly entity, the symbol annotation sequence
 occurs after the optional `id` of the declaration.
 
 For example, the following code:

--- a/Linking.md
+++ b/Linking.md
@@ -742,6 +742,12 @@ The text format for linking metadata is intended for WAT consumers that wish to
 emit relocatable object files, and WAT producers wish to emit human-readable
 relocation metadata for later creation of a relocatable object file.
 
+> [!NOTE]
+> This WAT-based text format is still a work in progress and not yet implemented
+> by widely used toolchains. Specifically, this is not the format used by
+> Clang/LLVM which uses a more traditional assembly-style format colloquially
+> refereed to as ths `.s` format.
+
 ## Relocations
 
 Relocations are represented as WebAssembly annotations of the form

--- a/Linking.md
+++ b/Linking.md
@@ -871,18 +871,36 @@ Data imports represented as WebAssembly annotations of the form
 - `qualifier` is one of the allowed qualifiers on a symbol declaration.
   Qualifiers may not repeat.
 
-| `<qualifier>`    | effect                                                                                         |
-|------------------|------------------------------------------------------------------------------------------------|
-| `weak`           | sets `WASM_SYM_BINDING_WEAK` symbol flag                                                       |
-| `static`         | sets `WASM_SYM_BINDING_LOCAL` symbol flag                                                      |
-| `hidden`         | sets `WASM_SYM_VISIBILITY_HIDDEN` symbol flag                                                  |
-| `retain`         | sets `WASM_SYM_NO_STRIP` symbol flag                                                           |
-| `thread_local`   | sets `WASM_SYM_TLS` symbol flag                                                                |
-| `size=<int>`     | sets symbol's `size` appropriately                                                             |
-| `offset=<int>`   | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately                     |
-| `name=<string>`  | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets symbol's `name_len`, `name_data` appropriately |
-| `priority=<int>` | adds symbol to `WASM_INIT_FUNCS` section with the given priority                               |
-| `comdat=<id>`    | adds symbol to a `comdat` with the given id                                                    |
+| `<qualifier>`             | effect                                        |
+|---------------------------|-----------------------------------------------|
+| `binding=<binding>`       | sets symbol flags according to `<binding>`    |
+| `visibility=<visibility>` | sets symbol flags according to `<visibility>` |
+| `retain`                  | sets `WASM_SYM_NO_STRIP` symbol flag          |
+| `thread_local`            | sets `WASM_SYM_TLS` symbol flag               |
+| `size=<int>`              | sets symbol's `size` appropriately            |
+| `offset=<int>`            | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately |
+| `name=<string>`           | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets symbol's `name_len`, `name_data` appropriately |
+| `priority=<int>`          | adds symbol to `WASM_INIT_FUNCS` section with the given priority |
+| `comdat=<id>`             | adds symbol to a `comdat` with the given id   |
+
+| `<binding>` | flag                     |
+|-------------|--------------------------|
+| `global`    | 0                        |
+| `local`     | `WASM_SYM_BINDING_LOCAL` |
+| `weak`      | `WASM_SYM_BINDING_WEAK`  |
+
+| `<visibility>` | flag                         |
+|----------------|------------------------------|
+| `default`      |                              |
+| `hidden`       | `WASM_SYM_VISIBILITY_HIDDEN` |
+
+Shorthands may be used in place of full qualifiers:
+
+| shorthand | resulting qualifier |
+|-----------|---------------------|
+| `hidden`  | `visibility=hidden` |
+| `local`   | `binding=local`     |
+| `weak`    | `binding=weak`      |
 
 - The `priority` qualifier may only be applied to function symbols.
 - The `size` and `offset` qualifiers may only be applied to data symbols.

--- a/Linking.md
+++ b/Linking.md
@@ -181,47 +181,6 @@ relocations applied to the CODE section, a relocation cannot straddle two
 functions, and for the DATA section relocations must lie within a data element's
 body.
 
-### Additional validation rules
-
-When perfoming validation on object files, care must be taken to ensure that
-meaningless relocations are not present in the binary.
-
-**Note**: Linker is not required to perform validation on its input object
-files.
-
-When relocations occur in the CODE section, only the following relocations may
-occur:
-
-| relocation type                 | condition the value at relocation offset |
-|---------------------------------|------------------------------------------|
-| `R_WASM_FUNCTION_INDEX_LEB`     | must represent a `funcidx`               |
-| `R_WASM_TYPE_INDEX_LEB`         | must represent a `typeidx`               |
-| `R_WASM_GLOBAL_INDEX_LEB`       | must represent a `globalidx`             |
-| `R_WASM_EVENT_INDEX_LEB`        | must represent a `tagidx`                |
-| `R_WASM_TABLE_NUMBER_LEB`       | must represent a `tableidx`              |
-| `R_WASM_TABLE_INDEX_SLEB`       | must represent an operand of `i32.const` |
-| `R_WASM_TABLE_INDEX_SLEB64`     | must represent an operand of `i64.const` |
-| `R_WASM_MEMORY_ADDR_SLEB`       | must represent an operand of `i32.const` |
-| `R_WASM_MEMORY_ADDR_REL_SLEB`   | must represent an operand of `i32.const` |
-| `R_WASM_MEMORY_ADDR_TLS_SLEB`   | must represent an operand of `i32.const` |
-| `R_WASM_MEMORY_ADDR_SLEB64`     | must represent an operand of `i64.const` |
-| `R_WASM_MEMORY_ADDR_REL_SLEB64` | must represent an operand of `i64.const` |
-| `R_WASM_MEMORY_ADDR_TLS_SLEB64` | must represent an operand of `i64.const` |
-| `R_WASM_MEMORY_ADDR_LEB`        | must represent the `offset` part of `memarg` where `memidx` references a 32-bit memory |
-| `R_WASM_MEMORY_ADDR_LEB64`      | must represent the `offset` part of `memarg` where `memidx` references a 64-bit memory |
-
-For `R_WASM_*_OFFSET_I*` relocations, the following condidions must hold for
-the addend:
-
-- If `index` references the CODE section, the addend must represent the first
-  byte of an instruction, or the byte after the last instruction.
-- If `index` references the DATA section, the addend must represent a valid
-  offset into a data segment's data area.
-- If `index` references the custom section, the addend must represent a valid
-  offset into that custom section's data area.
-
-All other relocations are considered invalid for the purposes of validation
-
 ## Linking Metadata Section
 
 A linking metadata section is a user-defined section with the name
@@ -362,8 +321,6 @@ For section symbols:
 | Field        | Type           | Description                                 |
 | ------------ | -------------- | ------------------------------------------- |
 | section      | `varuint32`    | the index of the target section             |
-
-Section symbols may only reference the CODE section, the DATA section, or custom sections.
 
 The current set of valid flags for symbols are:
 

--- a/Linking.md
+++ b/Linking.md
@@ -737,6 +737,10 @@ passive.
 
 # Text format
 
+The text format for linking metadata is intended for WAT consumers that wish to
+emit relocatable object files, and WAT producers wish to emit human-readable
+relocation metadata for later creation of a relocatable object file.
+
 ## Relocations
 
 Relocations are represented as WebAssembly annotations of the form

--- a/Linking.md
+++ b/Linking.md
@@ -894,17 +894,17 @@ identifier namespace corresponding to that symbol type.
 - `qualifier` is one of the allowed qualifiers on a symbol declaration.
   Qualifiers may not repeat.
 
-| `<qualifier>`             | effect                                        |
-|---------------------------|-----------------------------------------------|
-| `binding=<binding>`       | sets symbol flags according to `<binding>`    |
-| `visibility=<visibility>` | sets symbol flags according to `<visibility>` |
-| `retain`                  | sets `WASM_SYM_NO_STRIP` symbol flag          |
-| `tls`                     | sets `WASM_SYM_TLS` symbol flag               |
-| `size=<int>`              | sets symbol's `size` appropriately            |
-| `offset=<int>`            | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately |
-| `name=<string>`           | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets symbol's `name_len`, `name_data` appropriately |
-| `priority=<int>`          | adds symbol to `WASM_INIT_FUNCS` section with the given priority |
-| `comdat=<id>`             | adds symbol to a `comdat` with the given id   |
+| `<qualifier>`       | effect                                        |
+|---------------------|-----------------------------------------------|
+| `<binding>`         | sets symbol flags according to `<binding>`    |
+| `<visibility>`      | sets symbol flags according to `<visibility>` |
+| `retain`            | sets `WASM_SYM_NO_STRIP` symbol flag          |
+| `tls`               | sets `WASM_SYM_TLS` symbol flag               |
+| `(size <int>)`      | sets symbol's `size` appropriately            |
+| `(offset <int>)`    | sets `WASM_SYM_ABSOLUTE` symbol flag, sets symbol's `offset` appropriately |
+| `(name <string>)`   | sets `WASM_SYM_EXPLICIT_NAME` symbol flag, sets symbol's `name_len`, `name_data` appropriately |
+| `(init_prio <int>)` | adds symbol to `WASM_INIT_FUNCS` section with the given priority |
+| `(comdat <id>)`     | adds symbol to a `comdat` with the given id   |
 
 | `<binding>` | flag                     |
 |-------------|--------------------------|
@@ -914,16 +914,8 @@ identifier namespace corresponding to that symbol type.
 
 | `<visibility>` | flag                         |
 |----------------|------------------------------|
-| `default`      |                              |
+| `default`      | 0                            |
 | `hidden`       | `WASM_SYM_VISIBILITY_HIDDEN` |
-
-Shorthands may be used in place of full qualifiers:
-
-| shorthand | resulting qualifier |
-|-----------|---------------------|
-| `hidden`  | `visibility=hidden` |
-| `local`   | `binding=local`     |
-| `weak`    | `binding=weak`      |
 
 - The `priority` qualifier may only be applied to function symbols.
 - The `size` and `offset` qualifiers may only be applied to data symbols.
@@ -945,7 +937,7 @@ occurs after the optional `id` of the declaration.
 
 For example, the following code:
 ```wat
-(import "env" "foo" (func (@sym $a retain name="a") (@sym $b hidden name="b") (param) (result)))
+(import "env" "foo" (func (@sym $a retain (name "a")) (@sym $b hidden (name "b")) (param) (result)))
 ```
 declares 3 symbols: one primary symbol with the name of the index of the
 function, one symbol with the name `$a`, and one symbol with the name `$b`.
@@ -959,7 +951,7 @@ being defined.
 For example, a declaration of a 32-bit global with the name `$foo` and linkage
 name "foo" would look like following:
 ```wat
-(data (i32.const 0) (@sym $foo name="foo" size=4) "\00\00\00\00")
+(data (i32.const 0) (@sym $foo (name "foo") (size 4)) "\00\00\00\00")
 ```
 
 ### Data imports
@@ -1018,13 +1010,13 @@ Data segment flags are represented as WebAssembly annotations of the form
 - `qualifier` is one of the allowed qualifiers on a data segment declaration.
 Qualifiers may not repeat.
 
-| `<qualifier>`   | effect                                               |
-|-----------------|------------------------------------------------------|
-| `align=<int>`   | sets segment's `alignment` appropriately             |
-| `name=<string>` | sets segment's `name_len`, `name_data` appropriately |
-| `strings`       | sets `WASM_SEGMENT_FLAG_STRINGS` segment flag        |
-| `thread_local`  | sets `WASM_SEGMENT_FLAG_TLS` segment flag            |
-| `retain`        | sets `WASM_SEG_FLAG_RETAIN` segment flag             |
+| `<qualifier>`     | effect                                               |
+|-------------------|------------------------------------------------------|
+| `(align <int>)`   | sets segment's `alignment` appropriately             |
+| `(name <string>)` | sets segment's `name_len`, `name_data` appropriately |
+| `strings`         | sets `WASM_SEGMENT_FLAG_STRINGS` segment flag        |
+| `tls`             | sets `WASM_SEGMENT_FLAG_TLS` segment flag            |
+| `retain`          | sets `WASM_SEG_FLAG_RETAIN` segment flag             |
 
 If `align` is not specified, it is given a default value of 1.
 If `name` is not specified, it is given an empty default value.

--- a/Linking.md
+++ b/Linking.md
@@ -63,6 +63,10 @@ The "reloc." custom sections must come after the
 ["linking"](#linking-metadata-section) custom section in order to validate
 relocation indices.
 
+Any LEB128-encoded values should be maximally padded so that they can be
+rewritten without affecting the position of any other bytes. For instance, the
+function index 3 should be encoded as `0x83 0x80 0x80 0x80 0x00`.
+
 Relocations contain the following fields:
 
 | Field     | Type                | Description                     |
@@ -184,10 +188,6 @@ meaningless relocations are not present in the binary.
 
 **Note**: Linker is not required to perform validation on its input object
 files.
-
-All LEB128-encoded values that are to be relocated must be maximally padded so
-that they can be rewritten without affecting the position of any other bytes.
-For instance, the function index 3 must be encoded as `0x83 0x80 0x80 0x80 0x00`.
 
 When relocations occur in the CODE section, only the following relocations may
 occur:

--- a/Linking.md
+++ b/Linking.md
@@ -63,10 +63,6 @@ The "reloc." custom sections must come after the
 ["linking"](#linking-metadata-section) custom section in order to validate
 relocation indices.
 
-Any LEB128-encoded values should be maximally padded so that they can be
-rewritten without affecting the position of any other bytes. For instance, the
-function index 3 should be encoded as `0x83 0x80 0x80 0x80 0x00`.
-
 Relocations contain the following fields:
 
 | Field     | Type                | Description                     |
@@ -188,6 +184,10 @@ meaningless relocations are not present in the binary.
 
 **Note**: Linker is not required to perform validation on its input object
 files.
+
+All LEB128-encoded values that are to be relocated must be maximally padded so
+that they can be rewritten without affecting the position of any other bytes.
+For instance, the function index 3 must be encoded as `0x83 0x80 0x80 0x80 0x00`.
 
 When relocations occur in the CODE section, only the following relocations may
 occur:

--- a/Linking.md
+++ b/Linking.md
@@ -804,7 +804,7 @@ Symbol kinds marked with `*` are considered *primary*.
     function.
   - For `customtext` relocation method, this is the name of the custom section,
     so that if the addend is zero, the relocation points to the first byte of
-    data in that segment.
+    data in that section.
   - For other relocation methods, this denotes the symbol in the scope of that
     symbol kind.
 

--- a/Linking.md
+++ b/Linking.md
@@ -762,18 +762,16 @@ Relocations are represented as WebAssembly annotations of the form
 
 - `method` describes the type of relocation, so what kind of symbol we are relocating against and how to interpret that symbol.
 
-| `<method>`  | symbol kind | corresponding relocation constants | interpretation                    |
-|-------------|-------------|------------------------------------|-----------------------------------|
-| `tag`       | event*      | `R_WASM_EVENT_INDEX_*`             | Final WebAssembly event index     |
-| `table`     | table*      | `R_WASM_TABLE_NUMBER_*`            | Final WebAssembly table index (index of a table, not into one) |
-| `global`    | global*     | `R_WASM_GLOBAL_INDEX_*`            | Final WebAssembly global index    |
-| `func`      | function*   | `R_WASM_FUNCTION_INDEX_*`          | Final WebAssembly function index  |
-| `functable` | function    | `R_WASM_TABLE_INDEX_*`             | Index into the dynamic function table, used for taking address of functions |
-| `codeseg`   | function    | `R_WASM_FUNCTION_OFFSET`           | Offset into the function body from the start of the function |
-| `codesec`   | function    | `R_WASM_SECTION_OFFSET`            | Offset into the function section  |
-| `datasec`   | data        | `R_WASM_SECTION_OFFSET`            | Offset into the data section      |
-| `customsec` | N/A         | `R_WASM_SECTION_OFFSET`            | Offset into a custom section      |
-| `data`      | data        | `R_WASM_MEMORY_ADDR_*`             | WebAssembly linear memory address |
+| `<method>`   | symbol kind | corresponding relocation constants | interpretation                    |
+|--------------|-------------|------------------------------------|-----------------------------------|
+| `tag`        | event*      | `R_WASM_EVENT_INDEX_*`             | Final WebAssembly event index     |
+| `table`      | table*      | `R_WASM_TABLE_NUMBER_*`            | Final WebAssembly table index (index of a table, not into one) |
+| `global`     | global*     | `R_WASM_GLOBAL_INDEX_*`            | Final WebAssembly global index    |
+| `func`       | function*   | `R_WASM_FUNCTION_INDEX_*`          | Final WebAssembly function index  |
+| `functable`  | function    | `R_WASM_TABLE_INDEX_*`             | Index into the dynamic function table, used for taking address of functions |
+| `functext`   | function    | `R_WASM_FUNCTION_OFFSET`           | Offset into the function body from the start of the function |
+| `customtext` | section     | `R_WASM_SECTION_OFFSET`            | Offset into a custom section      |
+| `data`       | data        | `R_WASM_MEMORY_ADDR_*`             | WebAssembly linear memory address |
 
 Symbol kinds marked with `*` are considered *primary*.
 
@@ -792,16 +790,13 @@ Symbol kinds marked with `*` are considered *primary*.
 | nothing      | Zero addend          | always                                        |
 | `+<integer>` | Positive byte offset | `method` allows addend                        |
 | `-<integer>` | Negative byte offset | `method` allows addend and `format` is signed |
-| `<labeluse>` | Byte offest to label | `method` is either `codeseg` or `*sec`        |
+| `<labeluse>` | Byte offest to label | `method` is `*text`                           |
 
 - `symbol` describes the symbol against which to perform relocation.
-  - For `funcsec` relocation method, this is the function id, so that if the
+  - For `functext` relocation method, this is the function id, so that if the
     addend is zero, the relocation points to the first instruction of that
     function.
-  - For `datasec` relocation method, this is the data segment id, so that if
-    the addend is zero, the relocation points to the first byte of data in that
-    segment.
-  - For `customsec` relocation method, this is the name of the custom section,
+  - For `customtext` relocation method, this is the name of the custom section,
     so that if the addend is zero, the relocation points to the first byte of
     data in that segment.
   - For other relocation methods, this denotes the symbol in the scope of that

--- a/Linking.md
+++ b/Linking.md
@@ -745,6 +745,7 @@ Relocations are represented as WebAssembly annotations of the form
 ```
 
 - `format` determines the resulting format of a relocation
+
 |`<format>`| corresponding relocation constants | interpretation      |
 |----------|------------------------------------|---------------------|
 |`i32`     | `R_WASM_*_I32`                     | 4-byte [uint32]     |
@@ -755,6 +756,7 @@ Relocations are represented as WebAssembly annotations of the form
 |`sleb64`  | `R_WASM_*_SLEB`                    | 10-byte [varint64]  |
 
 - `method` describes the type of relocation, so what kind of symbol we are relocating against and how to interpret that symbol.
+
 | `<method>`  | symbol kind | corresponding relocation constants | interpretation                    |
 |-------------|-------------|------------------------------------|-----------------------------------|
 | `tag`       | event*      | `R_WASM_EVENT_INDEX_*`             | Final WebAssembly event index     |
@@ -770,6 +772,7 @@ Relocations are represented as WebAssembly annotations of the form
 Symbol kinds marked with `*` are considered *primary*.
 
 - `modifier` describes the additional attributes that a relocation might have.
+
 | `<modifier>` | corresponding relocation constants    | interpretation    |
 |--------------|---------------------------------------|-------------------|
 | nothing      | nothing                               | Normal relocation |
@@ -777,6 +780,7 @@ Symbol kinds marked with `*` are considered *primary*.
 | `tls`        | `R_WASM_*_TLS*`                       | Address relative to `env.__tls_base`, used for thread-local storage |
 
 - `addend` describes the additional components of a relocation.
+
 | `<addend>`   | interpretation       | condition                                                         |
 |--------------|----------------------|-------------------------------------------------------------------|
 | nothing      | Zero addend          | always                                                            |
@@ -911,6 +915,7 @@ Data segment flags are represented as WebAssembly annotations of the form
 ```
 
 - `qualifier` is one of the allowed qualifiers on a data segment declaration. Qualifiers may not repeat.
+
 | `<qualifier>`   | effect                                        |
 |-----------------|-----------------------------------------------|
 | `align=<int>`   | sets segment's `alignment` appropriately      |

--- a/Linking.md
+++ b/Linking.md
@@ -790,33 +790,61 @@ Symbol kinds marked with `*` are considered *primary*.
 | `<labeluse>` | Byte offest to label | `method` is either `codeseg` or `*sec`        |
 
 - `symbol` describes the symbol against which to perform relocation.
-  - For `funcsec` relocation method, this is the function id, so that if the addend is zero, the relocation points to the first instruction of that function.
-  - For `datasec` relocation method, this is the data segment id, so that if the addend is zero, the relocation points to the first byte of data in that segment.
-  - For `customsec` relocation method, this is the name of the custom section, so that if the addend is zero, the relocation points to the first byte of data in that segment.
-  - For other relocation methods, this denotes the symbol in the scope of that symbol kind.
+  - For `funcsec` relocation method, this is the function id, so that if the
+    addend is zero, the relocation points to the first instruction of that
+    function.
+  - For `datasec` relocation method, this is the data segment id, so that if
+    the addend is zero, the relocation points to the first byte of data in that
+    segment.
+  - For `customsec` relocation method, this is the name of the custom section,
+    so that if the addend is zero, the relocation points to the first byte of
+    data in that segment.
+  - For other relocation methods, this denotes the symbol in the scope of that
+    symbol kind.
 
-The relocation type is looked up from the combination of `format`, `method`, and `modifier`. If no relocation type exists, an error is raised.
+The relocation type is looked up from the combination of `format`, `method`,
+and `modifier`. If no relocation type exists, an error is raised.
 
-If a component of a relocation is predetermined, it must be skipped in the annotation text.
-If a component of a relocation is defaulted, it may be skipped in the annotation text.
-For example, a relocation into the function table by the index of `$foo` with a predetermined `format` would look like following:
+If a component of a relocation is predetermined, it must be skipped in the
+annotation text.
+
+If a component of a relocation is defaulted, it may be skipped in the
+annotation text.
+
+For example, a relocation into the function table by the index of `$foo` with a
+predetermined `format` would look like following:
 ```wat
 (@reloc functable $foo)
 ```
-If all components of a relocation annotation are skipped, the annotation may be omitted.
+If all components of a relocation annotation are skipped, the annotation may be
+omitted.
 
 ### Instruction relocations
 
-For every usage of `typeidx`, `funcidx`, `globalidx`, `tagidx`, a relocation annotation is added afterwards, with `format` predefined as `leb`, `method` predefined as the *primary* method for that type, and `symbol` defaulted as the *primary* symbol of that `idx`
+For every usage of `typeidx`, `funcidx`, `globalidx`, `tagidx`, a relocation
+annotation is added afterwards, with `format` predefined as `leb`, `method`
+predefined as the *primary* method for that type, and `symbol` defaulted as the
+*primary* symbol of that `idx`
 
-- For the `i32.const` instruction, a relocation annotation is added after the integer literal operand, with `format` predefined as `sleb`, and `method` is allowed to be either `data` or `functable`.
-- For the `i64.const` instruction, a relocation annotation is added after the integer literal operand, with `format` predefined as `sleb64`, and `method` is allowed to be either `data` or `functable`.
-- For the `i{32,64}.{load,store}*` instructions, a relocation annotation is added after the offset operand, with `format` predefined as `leb` if the *memory* being referenced is 32-bit, and `leb64` otherwise, and `method` predefined as `data`.
+- For the `i32.const` instruction, a relocation annotation is added after the
+  integer literal operand, with `format` predefined as `sleb`, and `method` is
+  allowed to be either `data` or `functable`.
+- For the `i64.const` instruction, a relocation annotation is added after the
+  integer literal operand, with `format` predefined as `sleb64`, and `method`
+  is allowed to be either `data` or `functable`.
+- For the `i{32,64}.{load,store}*` instructions, a relocation annotation is
+  added after the offset operand, with `format` predefined as `leb` if the
+  *memory* being referenced is 32-bit, and `leb64` otherwise, and `method`
+  predefined as `data`.
 
 ### Data relocations
 
-In data segments, relocation annotations can be interleaved into the data string sequence. When that happens, relocations are situated after the last byte of the value being relocated.
-For example, relocation of a 32-bit function pointer `$foo` into the data segment of size 4 would look like following:
+In data segments, relocation annotations can be interleaved into the data
+string sequence. When that happens, relocations are situated after the last
+byte of the value being relocated.
+
+For example, relocation of a 32-bit function pointer `$foo` into the data
+segment of size 4 would look like following:
 ```wat
 (data (i32.const 0) "\00\00\00\00" (@reloc i32 functbl $foo))
 ```
@@ -832,11 +860,16 @@ Data imports represented as WebAssembly annotations of the form
 (@sym.import.data <name> <qualifier>*)
 ```
 
-- `name` is the symbol name written as WebAssembly `id`, it is the name by which relocation annotations reference the symbol. If it is not present, the symbol is considered *primary* symbol for that WebAssembly object, its name is taken from the related object
+- `name` is the symbol name written as WebAssembly `id`, it is the name by
+  which relocation annotations reference the symbol. If it is not present, the
+  symbol is considered *primary* symbol for that WebAssembly object, its name
+  is taken from the related object
   - There may only be one primary symbol for each WebAssembly object.
-  - If a symbol is not associated with an object, it may not be the primary symbol.
+  - If a symbol is not associated with an object, it may not be the primary
+    symbol.
 
-- `qualifier` is one of the allowed qualifiers on a symbol declaration. Qualifiers may not repeat.
+- `qualifier` is one of the allowed qualifiers on a symbol declaration.
+  Qualifiers may not repeat.
 
 | `<qualifier>`    | effect                                                                                         |
 |------------------|------------------------------------------------------------------------------------------------|
@@ -856,28 +889,37 @@ Data imports represented as WebAssembly annotations of the form
 - The `size` and `name` qualifiers must be applied to data symbols.
 - The `name` qualifier must be applied to data imports.
 
-If all components of a symbol annotation are skipped, the annotation may be omitted.
+If all components of a symbol annotation are skipped, the annotation may be
+omitted.
 
 ### WebAssembly object symbols
 
-For symbols related to WebAssembly objects, the symbol annotation sequence occurs after the optional `id` of the declaration.
+For symbols related to WebAssembly objects, the symbol annotation sequence
+occurs after the optional `id` of the declaration.
+
 For example, the following code:
 ```wat
 (import "env" "foo" (func (@sym $a retain name="a") (@sym $b hidden name="b") (param) (result)))
 ```
-declares 3 symbols: one primary symbol with the name of the index of the function, one symbol with the name `$a`, and one symbol with the name `$b`.
+declares 3 symbols: one primary symbol with the name of the index of the
+function, one symbol with the name `$a`, and one symbol with the name `$b`.
 
 ### Data symbols
 
-Data symbol annotations can be interleaved into the data string sequence. When that happens, relocations are situated before the first byte of the value being defined.
-For example, a declaration of a 32-bit global with the name `$foo` and linkage name "foo" would look like following:
+Data symbol annotations can be interleaved into the data string sequence.
+When that happens, relocations are situated before the first byte of the value
+being defined.
+
+For example, a declaration of a 32-bit global with the name `$foo` and linkage
+name "foo" would look like following:
 ```wat
 (data (i32.const 0) (@sym $foo name="foo" size=4) "\00\00\00\00")
 ```
 
 ### Data imports
 
-Data imports occur in the same place as module fields. Data imports are always situated before data symbols.
+Data imports occur in the same place as module fields. Data imports are always
+situated before data symbols.
 
 ## COMDATs
 
@@ -885,13 +927,15 @@ COMDATs are represented as WebAssembly annotations of the form
 ```wat
 (@comdat <id> <string>)
 ```
-where `id` is the WebAssembly name of the COMDAT, and `<string>` is `name_len` and `name_str` of the `comdat`.
+where `id` is the WebAssembly name of the COMDAT, and `<string>` is `name_len`
+and `name_str` of the `comdat`.
 
 COMDAT declarations occur in the same place as module fields.
 
 ## Labels
 
-For some relocation types, an offset into a section/function is necessary. For these cases, labels exsist.
+For some relocation types, an offset into a section/function is necessary. For
+these cases, labels exsist.
 Labels are represented as WebAssembly annotations of the form
 ```wat
 (@sym.label <id>)
@@ -899,19 +943,23 @@ Labels are represented as WebAssembly annotations of the form
 
 ### Function labels
 Function labels occur in the same place as instructions.
-A label always denotes the first byte of the next instruction, or the byte after the end of the function's instruction stream, if there isn't a next instruction.
+A label always denotes the first byte of the next instruction, or the byte
+after the end of the function's instruction stream, if there isn't a next
+instruction.
 
 Function label names are local to the function in which they occur.
 
 ### Data labels
 Data labels can be interleaved into the data string sequence.
-When that happens, relocations are situated after the last byte of the value being relocated.
+When that happens, relocations are situated after the last byte of the value
+being relocated.
 
 Data label names are local to the data segment in which they occur.
 
 ### Custom labels
 Custom labels can be interleaved into the data string sequence.
-When that happens, relocations are situated after the last byte of the value being relocated.
+When that happens, relocations are situated after the last byte of the value
+being relocated.
 
 Custom label names are local to the custom section in which they occur.
 
@@ -921,7 +969,8 @@ Data segment flags are represented as WebAssembly annotations of the form
 (@sym.segment <qualifier>*)
 ```
 
-- `qualifier` is one of the allowed qualifiers on a data segment declaration. Qualifiers may not repeat.
+- `qualifier` is one of the allowed qualifiers on a data segment declaration.
+Qualifiers may not repeat.
 
 | `<qualifier>`   | effect                                               |
 |-----------------|------------------------------------------------------|
@@ -936,4 +985,5 @@ If `name` is not specified, it is given an empty default value.
 
 If all components of segment flags are skipped, the annotation may be omitted.
 
-Data segment annotation occurs after the optional `id` of the data segment declaration.
+Data segment annotation occurs after the optional `id` of the data segment
+declaration.


### PR DESCRIPTION
This PR proposes a vendor-neutral syntax for describing relocation information in WAT.

Unlike the syntax described in https://github.com/WebAssembly/wabt/pull/2649, this proposal is intended to express everything that the binary format can, including whatever the current proposed implementation in WABT does not support.  Of note here is the fact that `@sym` annotations can appear multiple times per declaration, the inclusion of COMDATs, segment infos, and the inclusion of labels and addends.