### PR TITLE
Document that Wasm signatures support components.

### DIFF
--- a/Signatures.md
+++ b/Signatures.md
@@ -1,6 +1,8 @@
-# WebAssembly module signatures
+# WebAssembly signatures
 
 This document describes a digital signature format specifically designed for WebAssembly modules.
+
+It also support [WebAssembly components](https://github.com/WebAssembly/component-model). Everything in this document that refers to "modules" also applies to "components".
 
 It satisfies the following requirements:
 

--- a/Signatures.md
+++ b/Signatures.md
@@ -2,7 +2,7 @@
 
 This document describes a digital signature format specifically designed for WebAssembly modules.
 
-It also support [WebAssembly components](https://github.com/WebAssembly/component-model). Everything in this document that refers to "modules" also applies to "components".
+It also supports [WebAssembly components](https://github.com/WebAssembly/component-model). As with modules, everything in components, including nested components, are stored in sections, including custom sections. Consequently, everything in this document that refers to "modules" also applies to "components".
 
 It satisfies the following requirements:
 


### PR DESCRIPTION
The Wasm signature format described in Signatures.md is general enough to work on components, and there is [component support in wasmsign2], so document that the format supports components.

[component support in wasmsign2]: https://github.com/wasm-signatures/wasmsign2/pull/5