### PR TITLE
Update function annotation location

### DIFF
--- a/CodeMetadata.md
+++ b/CodeMetadata.md
@@ -60,13 +60,16 @@ Example:
 ```
 (module
   (type (;0;) (func (param i32 result i32)))
-  (func (@metadata.code.hotness "\01") $test (type 0)
-    (@metadata.code.branch_hint "\00") if
+  (@metadata.code.hotness "\01")
+  (func $test (type 0)
+    (@metadata.code.branch_hint "\00")
+    if
       i32.const 0
       local.set 0
     end
     local.get 1
-    (@metadata.code.custom "aaa\13bb") return
+    (@metadata.code.custom "aaa\13bb")
+    return
   )
 )
 ```


### PR DESCRIPTION
As discussed in #251, function annotations should go before function definitions rather than after the `func` keyword. Update the example in CodeMetadata.md accordingly. Also update the example so that annotations consistently go on their own lines.

Fixes #251.